### PR TITLE
Сомов Иван. Задача 1. Вариант 5. Нахождение числа чередований знаков значений соседних элементов вектора

### DIFF
--- a/tasks/mpi/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_mpi_somov.cpp
+++ b/tasks/mpi/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_mpi_somov.cpp
@@ -1,0 +1,210 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "mpi/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_mpi_somov.hpp"
+
+TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_0) {
+  boost::mpi::communicator world;
+  const int n = 0;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test1.Validation(), false);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_1) {
+  boost::mpi::communicator world;
+  const int n = 1;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    somov_i_num_of_alternations_signs_mpi::GetRndVector(arr);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    int checker;
+    somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
+    ASSERT_EQ(out, checker);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_999) {
+  boost::mpi::communicator world;
+  const int n = 999;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    somov_i_num_of_alternations_signs_mpi::GetRndVector(arr);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    int checker;
+    somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
+    ASSERT_EQ(out, checker);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_10000) {
+  boost::mpi::communicator world;
+  const int n = 10000;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    somov_i_num_of_alternations_signs_mpi::GetRndVector(arr);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    int checker;
+    somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
+    ASSERT_EQ(out, checker);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_731) {
+  boost::mpi::communicator world;
+  const int n = 731;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    somov_i_num_of_alternations_signs_mpi::GetRndVector(arr);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    int checker;
+    somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
+    ASSERT_EQ(out, checker);
+  }
+}
+TEST(somov_i_num_of_alternations_signs_mpi, Norandom_check_1) {
+  boost::mpi::communicator world;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr = {-1, 1, -1, 1};
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, 3);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, Norandom_check_2) {
+  boost::mpi::communicator world;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr = {-1, 1, -1, 1, 1, 1, 1, 1, 1, 1};
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, 3);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, Norandom_check_3) {
+  boost::mpi::communicator world;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr = {-1, 1, -1, 1, 1, 1, -1, 1, -1, 1};
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns test1(task_data);
+  ASSERT_EQ(test1.Validation(), true);
+
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, 7);
+  }
+}

--- a/tasks/mpi/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_mpi_somov.cpp
+++ b/tasks/mpi/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_mpi_somov.cpp
@@ -3,7 +3,6 @@
 #include <boost/mpi/communicator.hpp>
 #include <cstdint>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -50,7 +49,7 @@ TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_1) {
   test1.Run();
   test1.PostProcessing();
   if (world.rank() == 0) {
-    int checker;
+    int checker = 0;
     somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
     ASSERT_EQ(out, checker);
   }
@@ -78,7 +77,7 @@ TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_999) {
   test1.Run();
   test1.PostProcessing();
   if (world.rank() == 0) {
-    int checker;
+    int checker = 0;
     somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
     ASSERT_EQ(out, checker);
   }
@@ -106,7 +105,7 @@ TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_10000) {
   test1.Run();
   test1.PostProcessing();
   if (world.rank() == 0) {
-    int checker;
+    int checker = 0;
     somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
     ASSERT_EQ(out, checker);
   }
@@ -134,7 +133,7 @@ TEST(somov_i_num_of_alternations_signs_mpi, Test_vec_731) {
   test1.Run();
   test1.PostProcessing();
   if (world.rank() == 0) {
-    int checker;
+    int checker = 0;
     somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
     ASSERT_EQ(out, checker);
   }

--- a/tasks/mpi/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_mpi_somov.hpp
+++ b/tasks/mpi/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_mpi_somov.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <boost/mpi/communicator.hpp>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace somov_i_num_of_alternations_signs_mpi {
+class NumOfAlternationsSigns : public ppc::core::Task {
+ public:
+  explicit NumOfAlternationsSigns(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  boost::mpi::communicator world_;
+  std::vector<int> input_;
+  int sz_ = 0;
+  int output_ = 0;
+};
+void GetRndVector(std::vector<int>& vec);
+
+void CheckForAlternationSigns(const std::vector<int>& vec, int& out);
+}  // namespace somov_i_num_of_alternations_signs_mpi

--- a/tasks/mpi/somov_i_num_of_alternations_signs/perf_tests/num_of_alternations_signs_perf_mpi_somov.cpp
+++ b/tasks/mpi/somov_i_num_of_alternations_signs/perf_tests/num_of_alternations_signs_perf_mpi_somov.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "mpi/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_mpi_somov.hpp"
+
+TEST(somov_i_num_of_alternations_signs_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  const int n = 100000000;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  auto test_task_mpi = std::make_shared<somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns>(task_data);
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_mpi);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  if (world.rank() == 0) {
+    int checker;
+    somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
+    ASSERT_EQ(out, checker);
+  }
+}
+
+TEST(somov_i_num_of_alternations_signs_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  const int n = 100000000;
+  // Create data
+  std::vector<int> arr;
+  int out = 0;
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    arr.resize(n);
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+    task_data->inputs_count.emplace_back(arr.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+    task_data->outputs_count.emplace_back(1);
+  }
+  auto test_task_mpi = std::make_shared<somov_i_num_of_alternations_signs_mpi::NumOfAlternationsSigns>(task_data);
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_mpi);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  if (world.rank() == 0) {
+    int checker;
+    somov_i_num_of_alternations_signs_mpi::CheckForAlternationSigns(arr, checker);
+    ASSERT_EQ(out, checker);
+  }
+}

--- a/tasks/mpi/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_mpi_somov.cpp
+++ b/tasks/mpi/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_mpi_somov.cpp
@@ -3,7 +3,7 @@
 #include <boost/mpi/collectives/scatter.hpp>
 #include <boost/mpi/collectives/scatterv.hpp>
 #include <cstring>
-#include <numeric>
+#include <functional>
 #include <random>
 #include <vector>
 
@@ -86,7 +86,7 @@ bool NumOfAlternationsSigns::RunImpl() {
   }
 
   int global_output = 0;
-  reduce(world_, output_, global_output, std::plus<int>(), 0);
+  reduce(world_, output_, global_output, std::plus<>(), 0);
 
   if (id == 0) {
     output_ = global_output;

--- a/tasks/mpi/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_mpi_somov.cpp
+++ b/tasks/mpi/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_mpi_somov.cpp
@@ -1,0 +1,103 @@
+#include <algorithm>
+#include <boost/mpi/collectives/reduce.hpp>
+#include <boost/mpi/collectives/scatter.hpp>
+#include <boost/mpi/collectives/scatterv.hpp>
+#include <cstring>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "mpi/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_mpi_somov.hpp"
+namespace somov_i_num_of_alternations_signs_mpi {
+void CheckForAlternationSigns(const std::vector<int>& vec, int& out) {
+  out = 0;
+  for (int i = 0; i < static_cast<int>(vec.size()) - 1; ++i) {
+    if (vec[i] * vec[i + 1] < 0) {
+      ++out;
+    }
+  }
+}
+void GetRndVector(std::vector<int>& vec) {
+  std::random_device rd;
+  std::default_random_engine reng(rd());
+  std::uniform_int_distribution<int> dist(-static_cast<int>(vec.size()) - 1, static_cast<int>(vec.size()) - 1);
+  std::ranges::generate(vec, [&dist, &reng] { return dist(reng); });
+}
+bool NumOfAlternationsSigns::PreProcessingImpl() {
+  // Init vectors
+  if (world_.rank() == 0) {
+    sz_ = static_cast<int>(task_data->inputs_count[0]);
+    input_ = std::vector<int>(sz_);
+    std::ranges::copy(reinterpret_cast<int*>(task_data->inputs[0]), reinterpret_cast<int*>(task_data->inputs[0]) + sz_,
+                      input_.begin());
+  }
+  return true;
+}
+
+bool NumOfAlternationsSigns::ValidationImpl() {
+  if (world_.rank() == 0) {
+    return (task_data->outputs_count[0] > 0 && task_data->inputs_count[0] > 0);
+  }
+  return true;
+}
+
+bool NumOfAlternationsSigns::RunImpl() {
+  int id = world_.rank();
+  int size = world_.size();
+  if (size == 1) {
+    for (int i = 0; i < static_cast<int>(input_.size()) - 1; ++i) {
+      if (input_[i] * input_[i + 1] < 0) {
+        ++output_;
+      }
+    }
+    return true;
+  }
+  std::vector<int> local_data;
+  std::vector<int> send_counts;
+  std::vector<int> displs;
+
+  if (id == 0) {
+    send_counts.resize(size);
+    displs.resize(size);
+    int base_size = sz_ / size;
+    int remainder = sz_ % size;
+
+    for (int i = 0; i < size; ++i) {
+      send_counts[i] = base_size + (i < remainder ? 1 : 0);
+    }
+    displs[0] = 0;
+    for (int i = 1; i < size; ++i) {
+      displs[i] = displs[i - 1] + send_counts[i - 1];
+    }
+    for (int i = 0; i < size - 1; ++i) {
+      if (displs[i] + send_counts[i] < sz_) {
+        send_counts[i]++;
+      }
+    }
+  }
+  int loc_vec_sz = 0;
+  scatter(world_, send_counts, loc_vec_sz, 0);
+  local_data.resize(loc_vec_sz);
+  scatterv(world_, input_.data(), send_counts, displs, local_data.data(), loc_vec_sz, 0);
+  for (int i = 0; i < static_cast<int>(local_data.size()) - 1; ++i) {
+    if (local_data[i] * local_data[i + 1] < 0) {
+      ++output_;
+    }
+  }
+
+  int global_output = 0;
+  reduce(world_, output_, global_output, std::plus<int>(), 0);
+
+  if (id == 0) {
+    output_ = global_output;
+  }
+  return true;
+}
+
+bool NumOfAlternationsSigns::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    reinterpret_cast<int*>(task_data->outputs[0])[0] = output_;
+  }
+  return true;
+}
+}  // namespace somov_i_num_of_alternations_signs_mpi

--- a/tasks/seq/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_seq_somov.cpp
+++ b/tasks/seq/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_seq_somov.cpp
@@ -25,7 +25,7 @@ TEST(somov_i_num_of_alternations_signs_seq, Test_vec_0) {
   test1.PreProcessing();
   test1.Run();
   test1.PostProcessing();
-  int checker;
+  int checker = 0;
   somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
   ASSERT_EQ(out, checker);
 }
@@ -48,7 +48,7 @@ TEST(somov_i_num_of_alternations_signs_seq, Test_vec_1) {
   test1.PreProcessing();
   test1.Run();
   test1.PostProcessing();
-  int checker;
+  int checker = 0;
   somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
   ASSERT_EQ(out, checker);
 }
@@ -71,7 +71,7 @@ TEST(somov_i_num_of_alternations_signs_seq, Test_vec_1000) {
   test1.PreProcessing();
   test1.Run();
   test1.PostProcessing();
-  int checker;
+  int checker = 0;
   somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
   ASSERT_EQ(out, checker);
 }
@@ -94,7 +94,7 @@ TEST(somov_i_num_of_alternations_signs_seq, Test_vec_10000) {
   test1.PreProcessing();
   test1.Run();
   test1.PostProcessing();
-  int checker;
+  int checker = 0;
   somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
   ASSERT_EQ(out, checker);
 }
@@ -117,7 +117,7 @@ TEST(somov_i_num_of_alternations_signs_seq, Test_vec_731) {
   test1.PreProcessing();
   test1.Run();
   test1.PostProcessing();
-  int checker;
+  int checker = 0;
   somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
   ASSERT_EQ(out, checker);
 }

--- a/tasks/seq/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_seq_somov.cpp
+++ b/tasks/seq/somov_i_num_of_alternations_signs/func_tests/num_of_alternations_signs_seq_somov.cpp
@@ -1,0 +1,185 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "seq/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_seq_somov.hpp"
+
+TEST(somov_i_num_of_alternations_signs_seq, Test_vec_0) {
+  const int n = 0;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, Test_vec_1) {
+  const int n = 1;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, Test_vec_1000) {
+  const int n = 1000;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, Test_vec_10000) {
+  const int n = 10000;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, Test_vec_731) {
+  const int n = 731;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}
+TEST(somov_i_num_of_alternations_signs_seq, Norandom_check_1) {
+  const int n = 3;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  arr = {-1, 1, -1};
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  ASSERT_EQ(out, 2);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, Norandom_check_2) {
+  const int n = 4;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  arr = {-1, -1, 1, 1};
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  ASSERT_EQ(out, 1);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, Norandom_check_3) {
+  const int n = 4;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  arr = {-1, 1, -1, 1};
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns test1(task_data);
+
+  ASSERT_EQ(test1.Validation(), true);
+  test1.PreProcessing();
+  test1.Run();
+  test1.PostProcessing();
+  ASSERT_EQ(out, 3);
+}

--- a/tasks/seq/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_seq_somov.hpp
+++ b/tasks/seq/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_seq_somov.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace somov_i_num_of_alternations_signs_seq {
+class NumOfAlternationsSigns : public ppc::core::Task {
+ public:
+  explicit NumOfAlternationsSigns(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  int sz_ = 0;
+  int output_ = 0;
+};
+void GetRndVector(std::vector<int>& vec);
+
+void CheckForAlternationSigns(const std::vector<int>& vec, int& out);
+}  // namespace somov_i_num_of_alternations_signs_seq

--- a/tasks/seq/somov_i_num_of_alternations_signs/perf_tests/num_of_alternations_signs_perf_seq_somov.cpp
+++ b/tasks/seq/somov_i_num_of_alternations_signs/perf_tests/num_of_alternations_signs_perf_seq_somov.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_seq_somov.hpp"
+
+TEST(somov_i_num_of_alternations_signs_seq, test_pipeline_run) {
+  const int n = 100000000;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns>(task_data);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}
+
+TEST(somov_i_num_of_alternations_signs_seq, test_task_run) {
+  const int n = 100000000;
+  // Create data
+  std::vector<int> arr(n);
+  int out = 0;
+  somov_i_num_of_alternations_signs_seq::GetRndVector(arr);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data->inputs_count.emplace_back(arr.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(&out));
+  task_data->outputs_count.emplace_back(1);
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<somov_i_num_of_alternations_signs_seq::NumOfAlternationsSigns>(task_data);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  int checker;
+  somov_i_num_of_alternations_signs_seq::CheckForAlternationSigns(arr, checker);
+  ASSERT_EQ(out, checker);
+}

--- a/tasks/seq/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_seq_somov.cpp
+++ b/tasks/seq/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_seq_somov.cpp
@@ -1,7 +1,5 @@
 #include <algorithm>
 #include <cstring>
-#include <iostream>
-#include <numeric>
 #include <random>
 #include <vector>
 

--- a/tasks/seq/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_seq_somov.cpp
+++ b/tasks/seq/somov_i_num_of_alternations_signs/src/num_of_alternations_signs_src_seq_somov.cpp
@@ -1,0 +1,50 @@
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "seq/somov_i_num_of_alternations_signs/include/num_of_alternations_signs_header_seq_somov.hpp"
+namespace somov_i_num_of_alternations_signs_seq {
+void CheckForAlternationSigns(const std::vector<int>& vec, int& out) {
+  out = 0;
+  for (int i = 0; i < static_cast<int>(vec.size()) - 1; ++i) {
+    if (vec[i] * vec[i + 1] < 0) {
+      ++out;
+    }
+  }
+}
+void GetRndVector(std::vector<int>& vec) {
+  std::random_device rd;
+  std::default_random_engine reng(rd());
+  std::uniform_int_distribution<int> dist(-static_cast<int>(vec.size()) - 1, static_cast<int>(vec.size()) - 1);
+  std::ranges::generate(vec, [&dist, &reng] { return dist(reng); });
+}
+bool NumOfAlternationsSigns::PreProcessingImpl() {
+  // Init vectors
+  sz_ = static_cast<int>(task_data->inputs_count[0]);
+  input_ = std::vector<int>(sz_);
+  std::ranges::copy(reinterpret_cast<int*>(task_data->inputs[0]), reinterpret_cast<int*>(task_data->inputs[0]) + sz_,
+                    input_.begin());
+  return true;
+}
+
+bool NumOfAlternationsSigns::ValidationImpl() { return (task_data->outputs_count[0] > 0); }
+
+bool NumOfAlternationsSigns::RunImpl() {
+  output_ = 0;
+
+  for (int i = 0; i < sz_ - 1; ++i) {
+    if (input_[i] * input_[i + 1] < 0) {
+      ++output_;
+    }
+  }
+  return true;
+}
+
+bool NumOfAlternationsSigns::PostProcessingImpl() {
+  reinterpret_cast<int*>(task_data->outputs[0])[0] = output_;
+  return true;
+}
+}  // namespace somov_i_num_of_alternations_signs_seq


### PR DESCRIPTION
SEQ:
Устраиваем последовательный проход по вектору и считаем число чередований.

MPI:
Каждый процесс, кроме последнего получает на один "правый" элемент больше, чтобы разрешить ситуации, когда у нас есть чередование на стыке двух частей.

К примеру
Вектор: 1 2 3 4 5 6 7
между 3 процессами будет разделен соответственно на вектора размеров 4 3 2.
0->1 2 3 4
1-> 4 5 6
2-> 6 7