### PR TITLE
Шпынов Никита. Задача 2. Вариант 2. Задача «Читатели-Писатели».

### DIFF
--- a/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
@@ -1,189 +1,216 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi/communicator.hpp>
-#include <boost/mpi/environment.hpp>
+#include <cstdint>
+#include <memory>
 #include <vector>
+
+#include "core/task/include/task.hpp"
 #include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
 TEST(Shpynov_N_readers_writers, test_single) {
-    boost::mpi::communicator world;
-  
-    if (world.size() < 2) {
-      GTEST_SKIP();
-    }
-  
-    std::vector<int> crit_res (1,0);
+  boost::mpi::communicator world_;
 
-    int expected_result = 0;
-    std::vector<int> returned_result (1,0);
-    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
-
-    if (world.rank() == 0) {
-
-      int writers_count = 0;
-      for (int i = 1; i < world.size(); i++) {
-        if (i % 2 != 0) writers_count++;
-      }
-      expected_result = writers_count;
-
-      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
-      task_data_mpi->inputs_count.emplace_back(1);
-      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
-      task_data_mpi->outputs_count.emplace_back(1);
-    }
-
-    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
-    ASSERT_EQ(TestTaskMPI.ValidationImpl(), true);
-    TestTaskMPI.PreProcessingImpl();
-    TestTaskMPI.RunImpl();
-    TestTaskMPI.PostProcessingImpl();
-    if (world.rank() == 0) {
-      ASSERT_EQ(expected_result, returned_result[0]);
-    }
+  if (world_.size() < 2) {
+    GTEST_SKIP();
   }
+
+  std::vector<int> crit_res(1, 0);
+
+  int expected_result = 0;
+  std::vector<int> returned_result(1, 0);
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world_.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
+        writers_count++;
+      }
+    }
+    expected_result = writers_count;
+
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(1);
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(1);
+  }
+
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+  if (world_.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result[0]);
+  }
+}
 
 TEST(Shpynov_N_readers_writers, test_alot) {
-    boost::mpi::communicator world;
+  boost::mpi::communicator world_;
 
-    if (world.size() < 2) {
-      GTEST_SKIP();
-    }
-
-    std::vector<int> crit_res = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
-
-    std::vector<int> expected_result(crit_res.size());
-    std::vector<int> returned_result(crit_res.size());
-
-    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
-
-    if (world.rank() == 0) {
-      int writers_count = 0;
-      for (int i = 1; i < world.size(); i++) {
-        if (i % 2 != 0) writers_count++;
-      }
-      for (int i = 0; i < crit_res.size(); i++) {
-        expected_result[i] = writers_count+crit_res[i];
-      }
-      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
-      task_data_mpi->inputs_count.emplace_back(crit_res.size());
-      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
-      task_data_mpi->outputs_count.emplace_back(crit_res.size());
-    }
-
-    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
-    ASSERT_EQ(TestTaskMPI.ValidationImpl(), true);
-    TestTaskMPI.PreProcessingImpl();
-    TestTaskMPI.RunImpl();
-    TestTaskMPI.PostProcessingImpl();
-    if (world.rank() == 0) {
-      ASSERT_EQ(expected_result, returned_result);
-    }
+  if (world_.size() < 2) {
+    GTEST_SKIP();
   }
+
+  std::vector<int> crit_res = {1, 2, 3, 1, 2, 3, 1, 2, 3,
+                               1, 2, 3, 1, 2, 3, 1, 2, 3};
+
+  std::vector<int> expected_result(crit_res.size());
+  std::vector<int> returned_result(crit_res.size());
+
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world_.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
+        writers_count++;
+      }
+    }
+    for (size_t i = 0; i < crit_res.size(); i++) {
+      expected_result[i] = writers_count + crit_res[i];
+    }
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(crit_res.size());
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(crit_res.size());
+  }
+
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+  if (world_.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
 
 TEST(Shpynov_N_readers_writers, test_multiple) {
-    boost::mpi::communicator world;
+  boost::mpi::communicator world_;
 
-    if (world.size() < 2) {
-      GTEST_SKIP();
-    }
-
-    std::vector<int> crit_res = {1, 2, 3};
-
-    std::vector<int> expected_result(crit_res.size());
-    std::vector<int> returned_result(crit_res.size());
-
-    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
-
-    if (world.rank() == 0) {
-      int writers_count = 0;
-      for (int i = 1; i < world.size(); i++) {
-        if (i % 2 != 0) writers_count++;
-      }
-      for (int i = 0; i < crit_res.size(); i++) {
-        expected_result[i] = writers_count + crit_res[i];
-      }
-      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
-      task_data_mpi->inputs_count.emplace_back(crit_res.size());
-      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
-      task_data_mpi->outputs_count.emplace_back(crit_res.size());
-    }
-
-    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
-    ASSERT_EQ(TestTaskMPI.ValidationImpl(), true);
-    TestTaskMPI.PreProcessingImpl();
-    TestTaskMPI.RunImpl();
-    TestTaskMPI.PostProcessingImpl();
-    if (world.rank() == 0) {
-      ASSERT_EQ(expected_result, returned_result);
-    }
+  if (world_.size() < 2) {
+    GTEST_SKIP();
   }
+
+  std::vector<int> crit_res = {1, 2, 3};
+
+  std::vector<int> expected_result(crit_res.size());
+  std::vector<int> returned_result(crit_res.size());
+
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world_.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
+        writers_count++;
+      }
+    }
+    for (size_t i = 0; i < crit_res.size(); i++) {
+      expected_result[i] = writers_count + crit_res[i];
+    }
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(crit_res.size());
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(crit_res.size());
+  }
+
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+  if (world_.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
 
 TEST(Shpynov_N_readers_writers, test_invalid_size) {
-    boost::mpi::communicator world;
+  boost::mpi::communicator world_;
 
-    if (world.size() < 2) {
-      GTEST_SKIP();
-    }
-
-    std::vector<int> crit_res = {};
-
-    std::vector<int> expected_result(crit_res.size());
-    std::vector<int> returned_result(crit_res.size());
-
-    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
-
-    if (world.rank() == 0) {
-      int writers_count = 0;
-      for (int i = 1; i < world.size(); i++) {
-        if (i % 2 != 0) writers_count++;
-      }
-      for (int i = 0; i < crit_res.size(); i++) {
-        expected_result[i] = writers_count + crit_res[i];
-      }
-      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
-      task_data_mpi->inputs_count.emplace_back(crit_res.size());
-      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
-      task_data_mpi->outputs_count.emplace_back(crit_res.size());
-    }
-
-    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
-
-    if (world.rank() == 0) {
-      ASSERT_NE(TestTaskMPI.ValidationImpl(), true);
-    }
+  if (world_.size() < 2) {
+    GTEST_SKIP();
   }
+
+  std::vector<int> crit_res = {};
+
+  std::vector<int> expected_result(crit_res.size());
+  std::vector<int> returned_result(crit_res.size());
+
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world_.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
+        writers_count++;
+      }
+    }
+    for (size_t i = 0; i < crit_res.size(); i++) {
+      expected_result[i] = writers_count + crit_res[i];
+    }
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(crit_res.size());
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(crit_res.size());
+  }
+
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+
+  if (world_.rank() == 0) {
+    ASSERT_NE(test_task_mpi.ValidationImpl(), true);
+  }
+}
 
 TEST(Shpynov_N_readers_writers, test_different_sizes) {
-    boost::mpi::communicator world;
+  boost::mpi::communicator world_;
 
-    if (world.size() < 2) {
-      GTEST_SKIP();
-    }
-
-    std::vector<int> crit_res = {};
-
-    std::vector<int> expected_result(crit_res.size()+1);
-    std::vector<int> returned_result(crit_res.size());
-
-    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
-
-    if (world.rank() == 0) {
-      int writers_count = 0;
-      for (int i = 1; i < world.size(); i++) {
-        if (i % 2 != 0) writers_count++;
-      }
-      for (int i = 0; i < crit_res.size(); i++) {
-        expected_result[i] = writers_count + crit_res[i];
-      }
-      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
-      task_data_mpi->inputs_count.emplace_back(crit_res.size());
-      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
-      task_data_mpi->outputs_count.emplace_back(crit_res.size());
-    }
-
-    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
-
-    if (world.rank() == 0) {
-      ASSERT_NE(TestTaskMPI.ValidationImpl(), true);
-    }
+  if (world_.size() < 2) {
+    GTEST_SKIP();
   }
+
+  std::vector<int> crit_res = {};
+
+  std::vector<int> expected_result(crit_res.size() + 1);
+  std::vector<int> returned_result(crit_res.size());
+
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world_.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
+        writers_count++;
+      }
+    }
+    for (size_t i = 0; i < crit_res.size(); i++) {
+      expected_result[i] = writers_count + crit_res[i];
+    }
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(crit_res.size());
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(crit_res.size());
+  }
+
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+
+  if (world_.rank() == 0) {
+    ASSERT_NE(test_task_mpi.ValidationImpl(), true);
+  }
+}

--- a/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
@@ -1,0 +1,189 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <vector>
+#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
+
+TEST(Shpynov_N_readers_writers, test_single) {
+    boost::mpi::communicator world;
+  
+    if (world.size() < 2) {
+      GTEST_SKIP();
+    }
+  
+    std::vector<int> crit_res (1,0);
+
+    int expected_result = 0;
+    std::vector<int> returned_result (1,0);
+    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+
+      int writers_count = 0;
+      for (int i = 1; i < world.size(); i++) {
+        if (i % 2 != 0) writers_count++;
+      }
+      expected_result = writers_count;
+
+      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
+      task_data_mpi->inputs_count.emplace_back(1);
+      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+      task_data_mpi->outputs_count.emplace_back(1);
+    }
+
+    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+    ASSERT_EQ(TestTaskMPI.ValidationImpl(), true);
+    TestTaskMPI.PreProcessingImpl();
+    TestTaskMPI.RunImpl();
+    TestTaskMPI.PostProcessingImpl();
+    if (world.rank() == 0) {
+      ASSERT_EQ(expected_result, returned_result[0]);
+    }
+  }
+
+TEST(Shpynov_N_readers_writers, test_alot) {
+    boost::mpi::communicator world;
+
+    if (world.size() < 2) {
+      GTEST_SKIP();
+    }
+
+    std::vector<int> crit_res = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
+
+    std::vector<int> expected_result(crit_res.size());
+    std::vector<int> returned_result(crit_res.size());
+
+    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      int writers_count = 0;
+      for (int i = 1; i < world.size(); i++) {
+        if (i % 2 != 0) writers_count++;
+      }
+      for (int i = 0; i < crit_res.size(); i++) {
+        expected_result[i] = writers_count+crit_res[i];
+      }
+      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
+      task_data_mpi->inputs_count.emplace_back(crit_res.size());
+      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+      task_data_mpi->outputs_count.emplace_back(crit_res.size());
+    }
+
+    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+    ASSERT_EQ(TestTaskMPI.ValidationImpl(), true);
+    TestTaskMPI.PreProcessingImpl();
+    TestTaskMPI.RunImpl();
+    TestTaskMPI.PostProcessingImpl();
+    if (world.rank() == 0) {
+      ASSERT_EQ(expected_result, returned_result);
+    }
+  }
+
+TEST(Shpynov_N_readers_writers, test_multiple) {
+    boost::mpi::communicator world;
+
+    if (world.size() < 2) {
+      GTEST_SKIP();
+    }
+
+    std::vector<int> crit_res = {1, 2, 3};
+
+    std::vector<int> expected_result(crit_res.size());
+    std::vector<int> returned_result(crit_res.size());
+
+    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      int writers_count = 0;
+      for (int i = 1; i < world.size(); i++) {
+        if (i % 2 != 0) writers_count++;
+      }
+      for (int i = 0; i < crit_res.size(); i++) {
+        expected_result[i] = writers_count + crit_res[i];
+      }
+      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
+      task_data_mpi->inputs_count.emplace_back(crit_res.size());
+      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+      task_data_mpi->outputs_count.emplace_back(crit_res.size());
+    }
+
+    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+    ASSERT_EQ(TestTaskMPI.ValidationImpl(), true);
+    TestTaskMPI.PreProcessingImpl();
+    TestTaskMPI.RunImpl();
+    TestTaskMPI.PostProcessingImpl();
+    if (world.rank() == 0) {
+      ASSERT_EQ(expected_result, returned_result);
+    }
+  }
+
+TEST(Shpynov_N_readers_writers, test_invalid_size) {
+    boost::mpi::communicator world;
+
+    if (world.size() < 2) {
+      GTEST_SKIP();
+    }
+
+    std::vector<int> crit_res = {};
+
+    std::vector<int> expected_result(crit_res.size());
+    std::vector<int> returned_result(crit_res.size());
+
+    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      int writers_count = 0;
+      for (int i = 1; i < world.size(); i++) {
+        if (i % 2 != 0) writers_count++;
+      }
+      for (int i = 0; i < crit_res.size(); i++) {
+        expected_result[i] = writers_count + crit_res[i];
+      }
+      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
+      task_data_mpi->inputs_count.emplace_back(crit_res.size());
+      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+      task_data_mpi->outputs_count.emplace_back(crit_res.size());
+    }
+
+    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+
+    if (world.rank() == 0) {
+      ASSERT_NE(TestTaskMPI.ValidationImpl(), true);
+    }
+  }
+
+TEST(Shpynov_N_readers_writers, test_different_sizes) {
+    boost::mpi::communicator world;
+
+    if (world.size() < 2) {
+      GTEST_SKIP();
+    }
+
+    std::vector<int> crit_res = {};
+
+    std::vector<int> expected_result(crit_res.size()+1);
+    std::vector<int> returned_result(crit_res.size());
+
+    std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+    if (world.rank() == 0) {
+      int writers_count = 0;
+      for (int i = 1; i < world.size(); i++) {
+        if (i % 2 != 0) writers_count++;
+      }
+      for (int i = 0; i < crit_res.size(); i++) {
+        expected_result[i] = writers_count + crit_res[i];
+      }
+      task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
+      task_data_mpi->inputs_count.emplace_back(crit_res.size());
+      task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+      task_data_mpi->outputs_count.emplace_back(crit_res.size());
+    }
+
+    Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+
+    if (world.rank() == 0) {
+      ASSERT_NE(TestTaskMPI.ValidationImpl(), true);
+    }
+  }

--- a/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-
+#include <boost/mpi/communicator.hpp>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -8,9 +8,9 @@
 #include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
 TEST(Shpynov_N_readers_writers, test_single) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -18,84 +18,77 @@ TEST(Shpynov_N_readers_writers, test_single) {
 
   int expected_result = 0;
   std::vector<int> returned_result(1, 0);
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
     expected_result = writers_count;
 
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(1);
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(1);
   }
 
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
   ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
   test_task_mpi.PreProcessingImpl();
   test_task_mpi.RunImpl();
   test_task_mpi.PostProcessingImpl();
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ASSERT_EQ(expected_result, returned_result[0]);
   }
 }
 
 TEST(Shpynov_N_readers_writers, test_alot) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
-  std::vector<int> crit_res = {1, 2, 3, 1, 2, 3, 1, 2, 3,
-                               1, 2, 3, 1, 2, 3, 1, 2, 3};
+  std::vector<int> crit_res = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
 
   std::vector<int> expected_result(crit_res.size());
   std::vector<int> returned_result(crit_res.size());
 
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
-    for (size_t i = 0; i < crit_res.size(); i++) {
+    for (unsigned long i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(crit_res.size());
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
 
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
   ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
   test_task_mpi.PreProcessingImpl();
   test_task_mpi.RunImpl();
   test_task_mpi.PostProcessingImpl();
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ASSERT_EQ(expected_result, returned_result);
   }
 }
 
 TEST(Shpynov_N_readers_writers, test_multiple) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -104,41 +97,38 @@ TEST(Shpynov_N_readers_writers, test_multiple) {
   std::vector<int> expected_result(crit_res.size());
   std::vector<int> returned_result(crit_res.size());
 
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
-    for (size_t i = 0; i < crit_res.size(); i++) {
+    for (unsigned long i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(crit_res.size());
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
 
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
   ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
   test_task_mpi.PreProcessingImpl();
   test_task_mpi.RunImpl();
   test_task_mpi.PostProcessingImpl();
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ASSERT_EQ(expected_result, returned_result);
   }
 }
 
 TEST(Shpynov_N_readers_writers, test_invalid_size) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -147,38 +137,35 @@ TEST(Shpynov_N_readers_writers, test_invalid_size) {
   std::vector<int> expected_result(crit_res.size());
   std::vector<int> returned_result(crit_res.size());
 
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
-    for (size_t i = 0; i < crit_res.size(); i++) {
+    for (unsigned long i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(crit_res.size());
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
 
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ASSERT_NE(test_task_mpi.ValidationImpl(), true);
   }
 }
 
 TEST(Shpynov_N_readers_writers, test_different_sizes) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -190,27 +177,25 @@ TEST(Shpynov_N_readers_writers, test_different_sizes) {
   std::shared_ptr<ppc::core::TaskData> task_data_mpi =
       std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
-    for (size_t i = 0; i < crit_res.size(); i++) {
+    for (unsigned long i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(crit_res.size());
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
 
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ASSERT_NE(test_task_mpi.ValidationImpl(), true);
   }
 }

--- a/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
@@ -175,8 +175,7 @@ TEST(Shpynov_N_readers_writers, test_different_sizes) {
   std::vector<int> expected_result(crit_res.size() + 1);
   std::vector<int> returned_result(crit_res.size());
 
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
     int writers_count = 0;

--- a/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
@@ -8,7 +8,7 @@
 #include "core/task/include/task.hpp"
 #include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
-TEST(Shpynov_N_readers_writers, test_single) {
+TEST(shpynov_n_readers_writers_mpi, test_single) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {
@@ -46,7 +46,7 @@ TEST(Shpynov_N_readers_writers, test_single) {
   }
 }
 
-TEST(Shpynov_N_readers_writers, test_alot) {
+TEST(shpynov_n_readers_writers_mpi, test_alot) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {
@@ -86,7 +86,7 @@ TEST(Shpynov_N_readers_writers, test_alot) {
   }
 }
 
-TEST(Shpynov_N_readers_writers, test_multiple) {
+TEST(shpynov_n_readers_writers_mpi, test_multiple) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {
@@ -126,7 +126,7 @@ TEST(Shpynov_N_readers_writers, test_multiple) {
   }
 }
 
-TEST(Shpynov_N_readers_writers, test_invalid_size) {
+TEST(shpynov_n_readers_writers_mpi, test_invalid_size) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {
@@ -163,7 +163,7 @@ TEST(Shpynov_N_readers_writers, test_invalid_size) {
   }
 }
 
-TEST(Shpynov_N_readers_writers, test_different_sizes) {
+TEST(shpynov_n_readers_writers_mpi, test_different_sizes) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {

--- a/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/func_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <boost/mpi/communicator.hpp>
 #include <cstdint>
 #include <memory>

--- a/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
@@ -2,11 +2,11 @@
 
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
-#include <cstdint>
-#include <string>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
@@ -2,16 +2,40 @@
 
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
-namespace shpynov_N_readers_writers_mpi {
+namespace shpynov_n_readers_writers_mpi {
+inline void Adder(std::vector<int> &a) {
+  for (unsigned long i = 0; i < a.size(); i++) {
+    a[i]++;
+  }
+}
+
+enum Procedures : std::uint8_t { kWriteBegin, kWriteEnd, kReadBegin, kReadEnd };
+
+inline Procedures Hasher(std::string const &in_string) {
+  if (in_string == "kWriteBegin") {
+    return kWriteBegin;
+  }
+  if (in_string == "kWriteEnd") {
+    return kWriteEnd;
+  }
+  if (in_string == "kReadBegin") {
+    return kReadBegin;
+  }
+  if (in_string == "kReadEnd") {
+    return kReadEnd;
+  }
+  return kWriteBegin;
+};
+
 class TestTaskMPI : public ppc::core::Task {
  public:
-  explicit TestTaskMPI(ppc::core::TaskDataPtr task_data)
-      : Task(std::move(task_data)) {}
+  explicit TestTaskMPI(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
   bool PreProcessingImpl() override;
   bool ValidationImpl() override;
   bool RunImpl() override;
@@ -22,4 +46,4 @@ class TestTaskMPI : public ppc::core::Task {
   std::vector<int> result_;
   boost::mpi::communicator world_;
 };
-}  // namespace shpynov_N_readers_writers_mpi
+}  // namespace shpynov_n_readers_writers_mpi

--- a/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
@@ -3,7 +3,6 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <cstdint>
+#include <string>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace Shpynov_N_readers_writers_mpi {
+class TestTaskMPI : public ppc::core::Task {
+public:
+  explicit TestTaskMPI(ppc::core::TaskDataPtr task_data)
+      : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+private:
+  std::vector<int> critical_resource;
+  std::vector<int> result;
+  boost::mpi::communicator world;
+};
+} // namespace Shpynov_N_readers_writers_mpi

--- a/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp
@@ -1,20 +1,15 @@
 #pragma once
 
-#include <gtest/gtest.h>
-
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <memory>
-#include <numeric>
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
-namespace Shpynov_N_readers_writers_mpi {
+namespace shpynov_N_readers_writers_mpi {
 class TestTaskMPI : public ppc::core::Task {
-public:
+ public:
   explicit TestTaskMPI(ppc::core::TaskDataPtr task_data)
       : Task(std::move(task_data)) {}
   bool PreProcessingImpl() override;
@@ -22,9 +17,9 @@ public:
   bool RunImpl() override;
   bool PostProcessingImpl() override;
 
-private:
-  std::vector<int> critical_resource;
-  std::vector<int> result;
-  boost::mpi::communicator world;
+ private:
+  std::vector<int> critical_resource_;
+  std::vector<int> result_;
+  boost::mpi::communicator world_;
 };
-} // namespace Shpynov_N_readers_writers_mpi
+}  // namespace shpynov_N_readers_writers_mpi

--- a/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
+
+TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
+  boost::mpi::communicator world;
+
+  if (world.size() < 2) {
+    GTEST_SKIP();
+  }
+
+  constexpr int kCount = 500;
+
+  std::vector<int> crit_res(kCount, 5);
+  std::vector<int> returned_result(kCount, 0);
+  std::vector<int> expected_result = crit_res;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world.size(); i++) {
+      if (i % 2 != 0)
+        writers_count++;
+    }
+    for (int i = 0; i < crit_res.size(); i++) {
+      expected_result[i] = writers_count + crit_res[i];
+    }
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(crit_res.size());
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(crit_res.size());
+  }
+  auto test_task_mpi =
+      std::make_shared<Shpynov_N_readers_writers_mpi::TestTaskMPI>(
+          task_data_mpi);
+  Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        current_time_point - t0)
+                        .count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_mpi);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  // Create Perf analyzer
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(Shpynov_N_readers_writers_perf, test_task_run) {
+  boost::mpi::communicator world;
+
+  if (world.size() < 2) {
+    GTEST_SKIP();
+  }
+
+  constexpr int kCount = 500;
+
+  std::vector<int> crit_res(kCount, 5);
+  std::vector<int> returned_result(kCount, 0);
+  std::vector<int> expected_result = crit_res;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
+      std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    int writers_count = 0;
+    for (int i = 1; i < world.size(); i++) {
+      if (i % 2 != 0)
+        writers_count++;
+    }
+    for (int i = 0; i < crit_res.size(); i++) {
+      expected_result[i] = writers_count + crit_res[i];
+    }
+    task_data_mpi->inputs.emplace_back(
+        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs_count.emplace_back(crit_res.size());
+    task_data_mpi->outputs.emplace_back(
+        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(crit_res.size());
+  }
+  auto test_task_mpi =
+      std::make_shared<Shpynov_N_readers_writers_mpi::TestTaskMPI>(
+          task_data_mpi);
+  Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        current_time_point - t0)
+                        .count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_mpi);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  // Create Perf analyzer
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}

--- a/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
@@ -94,8 +94,7 @@ TEST(Shpynov_N_readers_writers_perf, test_task_run) {
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
-  auto test_task_mpi =
-      std::make_shared<shpynov_n_readers_writers_mpi::TestTaskMPI>(task_data_mpi);
+  auto test_task_mpi = std::make_shared<shpynov_n_readers_writers_mpi::TestTaskMPI>(task_data_mpi);
   shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;

--- a/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
@@ -3,7 +3,6 @@
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -13,9 +12,9 @@
 #include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
 TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
-  boost::mpi::communicator world;
+  boost::mpi::communicator world_;
 
-  if (world.size() < 2) {
+  if (world_.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -28,13 +27,14 @@ TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
   std::shared_ptr<ppc::core::TaskData> task_data_mpi =
       std::make_shared<ppc::core::TaskData>();
 
-  if (world.rank() == 0) {
+  if (world_.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world.size(); i++) {
-      if (i % 2 != 0)
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
         writers_count++;
+      }
     }
-    for (int i = 0; i < crit_res.size(); i++) {
+    for (size_t i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
     task_data_mpi->inputs.emplace_back(
@@ -45,9 +45,9 @@ TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
   auto test_task_mpi =
-      std::make_shared<Shpynov_N_readers_writers_mpi::TestTaskMPI>(
+      std::make_shared<shpynov_N_readers_writers_mpi::TestTaskMPI>(
           task_data_mpi);
-  Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -66,16 +66,16 @@ TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   // Create Perf analyzer
 
-  if (world.rank() == 0) {
+  if (world_.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
     ASSERT_EQ(expected_result, returned_result);
   }
 }
 
 TEST(Shpynov_N_readers_writers_perf, test_task_run) {
-  boost::mpi::communicator world;
+  boost::mpi::communicator world_;
 
-  if (world.size() < 2) {
+  if (world_.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -88,13 +88,14 @@ TEST(Shpynov_N_readers_writers_perf, test_task_run) {
   std::shared_ptr<ppc::core::TaskData> task_data_mpi =
       std::make_shared<ppc::core::TaskData>();
 
-  if (world.rank() == 0) {
+  if (world_.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world.size(); i++) {
-      if (i % 2 != 0)
+    for (int i = 1; i < world_.size(); i++) {
+      if (i % 2 != 0) {
         writers_count++;
+      }
     }
-    for (int i = 0; i < crit_res.size(); i++) {
+    for (size_t i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
     task_data_mpi->inputs.emplace_back(
@@ -105,9 +106,9 @@ TEST(Shpynov_N_readers_writers_perf, test_task_run) {
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
   auto test_task_mpi =
-      std::make_shared<Shpynov_N_readers_writers_mpi::TestTaskMPI>(
+      std::make_shared<shpynov_N_readers_writers_mpi::TestTaskMPI>(
           task_data_mpi);
-  Shpynov_N_readers_writers_mpi::TestTaskMPI TestTaskMPI(task_data_mpi);
+  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -126,7 +127,7 @@ TEST(Shpynov_N_readers_writers_perf, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   // Create Perf analyzer
 
-  if (world.rank() == 0) {
+  if (world_.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
     ASSERT_EQ(expected_result, returned_result);
   }

--- a/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
@@ -10,7 +10,7 @@
 #include "core/task/include/task.hpp"
 #include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
-TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
+TEST(shpynov_n_readers_writers_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {
@@ -64,7 +64,7 @@ TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
   }
 }
 
-TEST(Shpynov_N_readers_writers_perf, test_task_run) {
+TEST(shpynov_n_readers_writers_mpi, test_task_run) {
   boost::mpi::communicator world;
 
   if (world.size() < 2) {

--- a/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/perf_tests/main.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi/communicator.hpp>
-#include <boost/mpi/environment.hpp>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -12,9 +11,9 @@
 #include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
 TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -24,39 +23,32 @@ TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
   std::vector<int> returned_result(kCount, 0);
   std::vector<int> expected_result = crit_res;
 
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
-    for (size_t i = 0; i < crit_res.size(); i++) {
+    for (unsigned long i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(crit_res.size());
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
-  auto test_task_mpi =
-      std::make_shared<shpynov_N_readers_writers_mpi::TestTaskMPI>(
-          task_data_mpi);
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
+  auto test_task_mpi = std::make_shared<shpynov_n_readers_writers_mpi::TestTaskMPI>(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                        current_time_point - t0)
-                        .count();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
   // Create and init perf results
@@ -66,16 +58,16 @@ TEST(Shpynov_N_readers_writers_perf, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   // Create Perf analyzer
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
     ASSERT_EQ(expected_result, returned_result);
   }
 }
 
 TEST(Shpynov_N_readers_writers_perf, test_task_run) {
-  boost::mpi::communicator world_;
+  boost::mpi::communicator world;
 
-  if (world_.size() < 2) {
+  if (world.size() < 2) {
     GTEST_SKIP();
   }
 
@@ -85,39 +77,33 @@ TEST(Shpynov_N_readers_writers_perf, test_task_run) {
   std::vector<int> returned_result(kCount, 0);
   std::vector<int> expected_result = crit_res;
 
-  std::shared_ptr<ppc::core::TaskData> task_data_mpi =
-      std::make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     int writers_count = 0;
-    for (int i = 1; i < world_.size(); i++) {
+    for (int i = 1; i < world.size(); i++) {
       if (i % 2 != 0) {
         writers_count++;
       }
     }
-    for (size_t i = 0; i < crit_res.size(); i++) {
+    for (unsigned long i = 0; i < crit_res.size(); i++) {
       expected_result[i] = writers_count + crit_res[i];
     }
-    task_data_mpi->inputs.emplace_back(
-        reinterpret_cast<uint8_t *>(crit_res.data()));
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(crit_res.data()));
     task_data_mpi->inputs_count.emplace_back(crit_res.size());
-    task_data_mpi->outputs.emplace_back(
-        reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(crit_res.size());
   }
   auto test_task_mpi =
-      std::make_shared<shpynov_N_readers_writers_mpi::TestTaskMPI>(
-          task_data_mpi);
-  shpynov_N_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
+      std::make_shared<shpynov_n_readers_writers_mpi::TestTaskMPI>(task_data_mpi);
+  shpynov_n_readers_writers_mpi::TestTaskMPI test_task_mpi_1(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                        current_time_point - t0)
-                        .count();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
   // Create and init perf results
@@ -127,7 +113,7 @@ TEST(Shpynov_N_readers_writers_perf, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   // Create Perf analyzer
 
-  if (world_.rank() == 0) {
+  if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
     ASSERT_EQ(expected_result, returned_result);
   }

--- a/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
@@ -9,9 +9,7 @@
 
 using namespace std::chrono_literals;
 
-// *** PARALLEL ALGORITHM *** //
-
-class C_sem {
+class C_sem { //semaphore class
 private:
   int signal;
 
@@ -74,7 +72,7 @@ bool Shpynov_N_readers_writers_mpi::TestTaskMPI::RunImpl() {
 
   if (world.rank() == 0) { // world represents monitor
 
-    while (!proc.IsFree()) {
+    while (!proc.IsFree()) { // processing requests untill all threads been used at least once
       std::string procedure;
       boost::mpi::status stat;
 

--- a/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
@@ -1,12 +1,12 @@
-#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
-
-#include <cstdint>
-#include <memory>
 #include <algorithm>
+#include <boost/mpi/status.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <chrono>
 #include <string>
 #include <thread>
 #include <vector>
+
+#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
 using namespace std::chrono_literals;
 
@@ -26,9 +26,9 @@ class CSem {  // semaphore class
   }
   void Lock() { signal_--; }
   void Unlock() { signal_++; }
-  bool [[nodiscard]] IsOnlyUser() const { return signal_ == 1; }
+  [[nodiscard]] bool IsOnlyUser() const { return signal_ == 1; }
 
-  bool [[nodiscard]] IsFree() const { return signal_ == 0; }
+  [[nodiscard]] bool IsFree() const { return signal_ == 0; }
 
   int CheckAnotherSem(CSem &writer, CSem &read_count) {
     if (this->TryLock()) {
@@ -92,7 +92,7 @@ bool shpynov_n_readers_writers_mpi::TestTaskMPI::RunImpl() {
       stat = world_.recv(boost::mpi::any_source, 0, procedure);
       int sender_name = stat.source();
       std::vector<int> new_res(critical_resource_.size());
-      int tmp;
+      int tmp = 0;
       switch (shpynov_n_readers_writers_mpi::Hasher(procedure)) {
         case kWriteBegin:
           if (writer.TryLock()) {

--- a/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
@@ -1,0 +1,166 @@
+#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+// *** PARALLEL ALGORITHM *** //
+
+class C_sem {
+private:
+  int signal;
+
+public:
+  C_sem(int sig) { signal = sig; }
+
+  bool TryLock() {
+    if (signal != 0) {
+      signal--;
+      return true;
+    }
+    return false;
+  }
+  void Lock() { signal--; }
+  void Unlock() { signal++; }
+  bool IsOnlyUser() { return signal == 1; }
+  bool IsFree() { return signal == 0; }
+};
+
+bool Shpynov_N_readers_writers_mpi::TestTaskMPI::ValidationImpl() {
+  if (world.rank() == 0) {
+    if (task_data->inputs_count[0] != task_data->outputs_count[0])
+      return false;
+    if (task_data->inputs_count[0] <= 0)
+      return false;
+  }
+  return true;
+}
+
+bool Shpynov_N_readers_writers_mpi::TestTaskMPI::PreProcessingImpl() {
+  if (world.rank() == 0) {
+    unsigned int input_size = task_data->inputs_count[0];
+    auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+    critical_resource = std::vector<int>(in_ptr, in_ptr + input_size);
+
+    unsigned int output_size = task_data->outputs_count[0];
+    result = std::vector<int>(output_size, 0);
+  }
+  return true;
+}
+
+enum procedures { WriteBegin, WriteEnd, ReadBegin, ReadEnd };
+
+procedures hasher(std::string const &inString) {
+  if (inString == "WriteBegin")
+    return WriteBegin;
+  if (inString == "WriteEnd")
+    return WriteEnd;
+  if (inString == "ReadBegin")
+    return ReadBegin;
+  if (inString == "ReadEnd")
+    return ReadEnd;
+  return WriteBegin;
+};
+bool Shpynov_N_readers_writers_mpi::TestTaskMPI::RunImpl() {
+  C_sem mutex(1);
+  C_sem writer(1);
+  C_sem read_count(0);
+  C_sem proc(world.size() - 1);
+
+  if (world.rank() == 0) { // world represents monitor
+
+    while (!proc.IsFree()) {
+      std::string procedure;
+      boost::mpi::status stat;
+
+      stat = world.recv(boost::mpi::any_source, 0, procedure);
+      int sender_name = stat.source();
+      std::vector<int> NewRes(critical_resource.size());
+      switch (hasher(procedure)) {
+      case WriteBegin:
+        if (writer.TryLock()) {
+          world.send(sender_name, 2, std::string("clear"));
+          world.send(sender_name, 1, critical_resource);
+        } else {
+          world.send(sender_name, 2, std::string("wait"));
+        }
+        break;
+
+      case WriteEnd:
+        world.recv(sender_name, 3, NewRes);
+        critical_resource = NewRes;
+        writer.Unlock();
+        proc.Lock();
+        break;
+
+      case ReadBegin:
+        if (mutex.TryLock()) {
+          read_count.Unlock();
+          if (read_count.IsOnlyUser()) {
+            if (writer.TryLock()) {
+            } else {
+              world.send(sender_name, 2, std::string("wait"));
+              mutex.Unlock();
+              continue;
+            }
+          }
+          mutex.Unlock();
+          world.send(sender_name, 2, std::string("clear"));
+          world.send(sender_name, 1, critical_resource);
+        } else
+          world.send(sender_name, 2, std::string("wait"));
+        break;
+
+      case ReadEnd:
+        mutex.Lock();
+        read_count.Lock();
+        if (read_count.IsFree()) {
+          writer.Unlock();
+        }
+        mutex.Unlock();
+        proc.Lock();
+        break;
+
+      default:
+        break;
+      }
+    }
+    result = critical_resource;
+  } else if (world.rank() % 2 == 0) { // reader
+    std::string resp = "wait";
+    while (resp != "clear") {
+      world.send(0, 0, std::string("ReadBegin"));
+      world.recv(0, 2, resp);
+    }
+    world.recv(0, 1, critical_resource);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    world.send(0, 0, std::string("ReadEnd"));
+  } else { // writer
+    std::string resp = "wait";
+    while (resp != "clear") {
+      world.send(0, 0, std::string("WriteBegin"));
+      world.recv(0, 2, resp);
+    }
+    world.recv(0, 1, critical_resource);
+    for (int i = 0; i < critical_resource.size(); i++) {
+      critical_resource[i] += 1;
+    }
+    world.send(0, 3, critical_resource);
+    world.send(0, 0, std::string("WriteEnd"));
+  }
+  world.barrier();
+  return true;
+}
+bool Shpynov_N_readers_writers_mpi::TestTaskMPI::PostProcessingImpl() {
+  if (world.rank() == 0) {
+    auto *output = reinterpret_cast<int *>(task_data->outputs[0]);
+    std::copy(result.begin(), result.end(), output);
+    return true;
+  }
+  return true;
+}

--- a/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_reader_writer/src/readers_writers_mpi.cpp
@@ -1,12 +1,12 @@
+#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
+
 #include <algorithm>
-#include <boost/mpi/status.hpp>
 #include <boost/mpi/communicator.hpp>
+#include <boost/mpi/status.hpp>
 #include <chrono>
 #include <string>
 #include <thread>
 #include <vector>
-
-#include "mpi/Shpynov_N_reader_writer/include/readers_writers_mpi.hpp"
 
 using namespace std::chrono_literals;
 
@@ -45,7 +45,7 @@ class CSem {  // semaphore class
     return 0;
   }
 
-  void UnlockIfFree(CSem &writer) const{
+  void UnlockIfFree(CSem &writer) const {
     if (this->IsFree()) {
       writer.Unlock();
     }


### PR DESCRIPTION
Классическая задача о читателях и писателях. Реализован вариант с доступом к памяти неограниченного числа читателей или одного писателя. 

> Как только появился хоть один писатель, никого больше не пускать. Все остальные могут простаивать. - wiki

Главный процесс выступает в роли монитора ресурсов. С помощью семафоров **mutex** и **monitor** он управляет доступом к секции критических данных, представленной вектором int'ов. Либо неограниченное число читателей одновременно получают доступ к данным, либо только один писатель записывает туда информацию. Все остальные процессы неограниченно ждут своей очереди.

Все остальные процессы, кроме главного, являются читателями и писателями. 

Первые ждут освобождения от писателей семафора writer, при получении доступа, они его дня писателей закрывают, (при условии, что других читателей еще нет и это не было уже сделано - за этим следит семафор mutex). Последний читатель возвращает доступ к КС. Чтение неразделяемых данных условно реализовано простоем в 1мс

Писатели же, в свою очередь, ждут, пока КС освободится полностью, после чего они ее захватывают и пишут, затем освобождают. Запись данных условно реализована прибавлением 1 к каждому элементу вектора.