### PR TITLE
Шпынов Никита. Задача 3. Вариант 18. Поразрядная сортировка для целых чисел с простым слиянием.

### DIFF
--- a/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -60,7 +60,6 @@ TEST(shpynov_n_radix_sort_mpi, test_tiny_vector) {
   }
 }
 TEST(shpynov_n_radix_sort_mpi, test_lots_of_zeros) {
-  GTEST_SKIP();
   boost::mpi::communicator world;
   constexpr int kCount = 10;
   std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -192,6 +191,7 @@ TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers
     ASSERT_EQ(expected_result, returned_result);
   }
 }
+
 TEST(shpynov_n_radix_sort_mpi, test_invalid) {
   boost::mpi::communicator world;
   std::vector<int> input_vec;
@@ -208,5 +208,86 @@ TEST(shpynov_n_radix_sort_mpi, test_invalid) {
   shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
   if (world.rank() == 0) {
     ASSERT_NE(test_task_mpi.ValidationImpl(), true);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_tiny_random_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(2);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+
+  std::vector<int> returned_result(input_vec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_average_random_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(30);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+
+  std::vector<int> returned_result(input_vec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_big_random_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(2000);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+
+  std::vector<int> returned_result(input_vec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
   }
 }

--- a/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -1,0 +1,212 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp"
+
+TEST(shpynov_n_radix_sort_mpi, test_single_num) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec(1, 0);
+
+  std::vector<int> expected_result(1, 0);
+  std::vector<int> returned_result(1, 0);
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(1);
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(1);
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_tiny_vector) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec = {33, 22};
+
+  std::vector<int> expected_result = {22, 33};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+TEST(shpynov_n_radix_sort_mpi, test_lots_of_zeros) {
+  GTEST_SKIP();
+  boost::mpi::communicator world;
+  constexpr int kCount = 10;
+  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  for (int i = 0; i < kCount; i++) {
+    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
+  }
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659};
+
+  std::vector<int> expected_result = {0, 1, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_neg_numbers) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec = {-17, -33, -22, -420, -1, -5837, -659};
+
+  std::vector<int> expected_result = {-5837, -659, -420, -33, -22, -17, -1};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659, -4, -28, -76, -110291};
+
+  std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers_with_same_nums) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec = {17, 33, 22, 420, 1, 17, 0, 5837, 659, -4, -28, 0, -76, -4, -110291};
+
+  std::vector<int> expected_result = {-110291, -76, -28, -4, -4, 0, 0, 1, 17, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_mpi.ValidationImpl(), true);
+  }
+  test_task_mpi.PreProcessingImpl();
+  test_task_mpi.RunImpl();
+  test_task_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+TEST(shpynov_n_radix_sort_mpi, test_invalid) {
+  boost::mpi::communicator world;
+  std::vector<int> inputVec;
+
+  std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_mpi->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_mpi::TestTaskMPI test_task_mpi(task_data_mpi);
+  if (world.rank() == 0) {
+    ASSERT_NE(test_task_mpi.ValidationImpl(), true);
+  }
+}

--- a/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -10,13 +10,13 @@
 
 TEST(shpynov_n_radix_sort_mpi, test_single_num) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec(1, 0);
+  std::vector<int> input_vec(1, 0);
 
   std::vector<int> expected_result(1, 0);
   std::vector<int> returned_result(1, 0);
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
   task_data_mpi->inputs_count.emplace_back(1);
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(1);
@@ -36,14 +36,14 @@ TEST(shpynov_n_radix_sort_mpi, test_single_num) {
 
 TEST(shpynov_n_radix_sort_mpi, test_tiny_vector) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec = {33, 22};
+  std::vector<int> input_vec = {33, 22};
 
   std::vector<int> expected_result = {22, 33};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 
@@ -63,17 +63,17 @@ TEST(shpynov_n_radix_sort_mpi, test_lots_of_zeros) {
   GTEST_SKIP();
   boost::mpi::communicator world;
   constexpr int kCount = 10;
-  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   for (int i = 0; i < kCount; i++) {
-    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
     expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
   }
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 
@@ -91,14 +91,14 @@ TEST(shpynov_n_radix_sort_mpi, test_lots_of_zeros) {
 }
 TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659};
+  std::vector<int> input_vec = {17, 33, 22, 420, 1, 0, 5837, 659};
 
   std::vector<int> expected_result = {0, 1, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 
@@ -117,14 +117,14 @@ TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length) {
 
 TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_neg_numbers) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec = {-17, -33, -22, -420, -1, -5837, -659};
+  std::vector<int> input_vec = {-17, -33, -22, -420, -1, -5837, -659};
 
   std::vector<int> expected_result = {-5837, -659, -420, -33, -22, -17, -1};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 
@@ -143,14 +143,14 @@ TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_neg_numbers) {
 
 TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659, -4, -28, -76, -110291};
+  std::vector<int> input_vec = {17, 33, 22, 420, 1, 0, 5837, 659, -4, -28, -76, -110291};
 
   std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 
@@ -169,14 +169,14 @@ TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers
 
 TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers_with_same_nums) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec = {17, 33, 22, 420, 1, 17, 0, 5837, 659, -4, -28, 0, -76, -4, -110291};
+  std::vector<int> input_vec = {17, 33, 22, 420, 1, 17, 0, 5837, 659, -4, -28, 0, -76, -4, -110291};
 
   std::vector<int> expected_result = {-110291, -76, -28, -4, -4, 0, 0, 1, 17, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 
@@ -194,14 +194,14 @@ TEST(shpynov_n_radix_sort_mpi, test_some_numbers_diff_length_pos_and_neg_numbers
 }
 TEST(shpynov_n_radix_sort_mpi, test_invalid) {
   boost::mpi::communicator world;
-  std::vector<int> inputVec;
+  std::vector<int> input_vec;
 
   std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
-  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_mpi->inputs_count.emplace_back(inputVec.size());
+  task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_mpi->inputs_count.emplace_back(input_vec.size());
   task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_mpi->outputs_count.emplace_back(returned_result.size());
 

--- a/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <boost/mpi/communicator.hpp>
 #include <cstdint>
 #include <memory>
@@ -215,7 +216,7 @@ TEST(shpynov_n_radix_sort_mpi, test_tiny_random_vector) {
   boost::mpi::communicator world;
   std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(2);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
@@ -242,7 +243,7 @@ TEST(shpynov_n_radix_sort_mpi, test_average_random_vector) {
   boost::mpi::communicator world;
   std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(30);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
@@ -269,7 +270,7 @@ TEST(shpynov_n_radix_sort_mpi, test_big_random_vector) {
   boost::mpi::communicator world;
   std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(2000);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
@@ -17,7 +17,7 @@ inline std::vector<int> GetRandVec(int size) {
   std::vector<int> vec(size);
   std::srand(std::time({}));
   for (int i = 0; i < size; ++i) {
-    vec[i] = static_cast<int>((std::rand() % 2000) - 1000);
+    vec[i] = (std::rand() % 2000) - 1000;
   }
   return vec;
 }

--- a/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace shpynov_n_radix_sort_mpi {
+
+inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
+  int Max = 0;
+  for (int i = 0; i < vec.size(); i++) {
+    if (std::abs(vec[i]) > Max) {
+      Max = std::abs(vec[i]);
+    }
+  }
+  int count = 0;
+  while (Max) {
+    Max /= 10;
+    count++;
+  }
+  return count;
+}
+
+inline std::vector<int> SortBySingleDigit(std::vector<int>& vec, int DigitPlace) {
+  std::vector<int> output(vec.size());
+  std::vector<int> count(10, 0);
+  for (size_t i = 0; i < vec.size(); i++) {
+    count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10]++;
+  }
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+  for (int i = vec.size() - 1; i >= 0; i--) {
+    output[count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10] - 1] = vec[i];
+    count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10]--;
+  }
+  for (int i = 0; i < vec.size(); i++) {
+    vec[i] = output[i];
+  }
+  return output;
+}
+
+inline std::vector<int> RadixSort(std::vector<int>& vec) {
+  std::vector<int> vecPos;
+  std::vector<int> vecNeg;
+  int MaxPosNum = 0;
+  int MaxNegNum = 0;
+  for (int i = 0; i < vec.size(); i++) {
+    if (vec[i] < 0) {
+      vecNeg.push_back(std::abs(vec[i]));
+      MaxNegNum = GetMaxAmountOfDigits(vecNeg);
+    } else {
+      vecPos.push_back(vec[i]);
+      MaxPosNum = GetMaxAmountOfDigits(vecPos);
+    }
+  }
+  for (int i = 0; i < MaxNegNum; i++) {
+    SortBySingleDigit(vecNeg, i);
+  }
+  std::reverse(vecNeg.begin(), vecNeg.end());
+  for (int i = 0; i < vecNeg.size(); i++) {
+    vecNeg[i] = -vecNeg[i];
+  }
+  for (int i = 0; i < MaxPosNum; i++) {
+    SortBySingleDigit(vecPos, i);
+  }
+  vec.clear();
+  vec.insert(vec.end(), vecNeg.begin(), vecNeg.end());
+  vec.insert(vec.end(), vecPos.begin(), vecPos.end());
+  return vec;
+}
+
+class TestTaskSEQ : public ppc::core::Task {
+ public:
+  explicit TestTaskSEQ(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> result_;
+};
+
+class TestTaskMPI : public ppc::core::Task {
+ public:
+  explicit TestTaskMPI(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> result_;
+  boost::mpi::communicator world_;
+};
+
+}  // namespace shpynov_n_radix_sort_mpi

--- a/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
@@ -4,7 +4,6 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
-#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -13,13 +12,13 @@
 namespace shpynov_n_radix_sort_mpi {
 
 inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
-  int maxNum = 0;
+  int max_num = 0;
   for (int i = 0; i < (int)vec.size(); i++) {
-    maxNum = std::max(std::abs(vec[i]), maxNum);
+    max_num = std::max(std::abs(vec[i]), max_num);
   }
   int count = 0;
-  while (maxNum != 0) {
-    maxNum /= 10;
+  while (max_num != 0) {
+    max_num /= 10;
     count++;
   }
   return count;

--- a/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp
@@ -4,12 +4,23 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
+#include <cstdlib>
+#include <ctime>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
 namespace shpynov_n_radix_sort_mpi {
+
+inline std::vector<int> GetRandVec(int size) {
+  std::vector<int> vec(size);
+  std::srand(std::time({}));
+  for (int i = 0; i < size; ++i) {
+    vec[i] = static_cast<int>((std::rand() % 2000) - 1000);
+  }
+  return vec;
+}
 
 inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
   int max_num = 0;

--- a/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <boost/mpi/communicator.hpp>
 #include <chrono>
 #include <cstdint>
@@ -12,13 +13,10 @@
 
 TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
-  constexpr int kCount = 10;
-  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  for (int i = 0; i < kCount; i++) {
-    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
-    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
-  }
+  constexpr int kCount = 5000;
+  std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(kCount);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
@@ -32,7 +30,7 @@ TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
 
   auto test_task_mpi = std::make_shared<shpynov_n_radix_sort_mpi::TestTaskMPI>(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 50;
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   perf_attr->current_timer = [&] {
@@ -55,13 +53,10 @@ TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
 
 TEST(shpynov_n_radix_sort_mpi, test_task_run) {
   boost::mpi::communicator world;
-  constexpr int kCount = 10;
-  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  for (int i = 0; i < kCount; i++) {
-    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
-    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
-  }
+  constexpr int kCount = 5000;
+  std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(kCount);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
@@ -73,7 +68,7 @@ TEST(shpynov_n_radix_sort_mpi, test_task_run) {
   }
   auto test_task_mpi = std::make_shared<shpynov_n_radix_sort_mpi::TestTaskMPI>(task_data_mpi);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 50;
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   perf_attr->current_timer = [&] {

--- a/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -16,7 +16,7 @@ TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
   constexpr int kCount = 5000;
   std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(kCount);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
@@ -56,7 +56,7 @@ TEST(shpynov_n_radix_sort_mpi, test_task_run) {
   constexpr int kCount = 5000;
   std::vector<int> input_vec = shpynov_n_radix_sort_mpi::GetRandVec(kCount);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();

--- a/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp"
+
+TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+  constexpr int kCount = 10;
+  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  for (int i = 0; i < kCount; i++) {
+    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
+  }
+
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+    task_data_mpi->inputs_count.emplace_back(inputVec.size());
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(returned_result.size());
+  }
+
+  auto test_task_mpi = std::make_shared<shpynov_n_radix_sort_mpi::TestTaskMPI>(task_data_mpi);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_mpi);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  // Create Perf analyzer
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}
+
+TEST(shpynov_n_radix_sort_mpi, test_task_run) {
+  boost::mpi::communicator world;
+  constexpr int kCount = 10;
+  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  for (int i = 0; i < kCount; i++) {
+    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
+  }
+
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+    task_data_mpi->inputs_count.emplace_back(inputVec.size());
+    task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+    task_data_mpi->outputs_count.emplace_back(returned_result.size());
+  }
+  auto test_task_mpi = std::make_shared<shpynov_n_radix_sort_mpi::TestTaskMPI>(task_data_mpi);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_mpi);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  // Create Perf analyzer
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    ASSERT_EQ(expected_result, returned_result);
+  }
+}

--- a/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -13,19 +13,19 @@
 TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
   constexpr int kCount = 10;
-  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   for (int i = 0; i < kCount; i++) {
-    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
     expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
   }
 
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
 
   if (world.rank() == 0) {
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-    task_data_mpi->inputs_count.emplace_back(inputVec.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+    task_data_mpi->inputs_count.emplace_back(input_vec.size());
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(returned_result.size());
   }
@@ -56,18 +56,18 @@ TEST(shpynov_n_radix_sort_mpi, test_pipeline_run) {
 TEST(shpynov_n_radix_sort_mpi, test_task_run) {
   boost::mpi::communicator world;
   constexpr int kCount = 10;
-  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   for (int i = 0; i < kCount; i++) {
-    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
     expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
   }
 
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_mpi = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-    task_data_mpi->inputs_count.emplace_back(inputVec.size());
+    task_data_mpi->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+    task_data_mpi->inputs_count.emplace_back(input_vec.size());
     task_data_mpi->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
     task_data_mpi->outputs_count.emplace_back(returned_result.size());
   }

--- a/tasks/mpi/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort_mpi.cpp
@@ -1,0 +1,109 @@
+
+#include "mpi/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort_mpi.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+// *** SEQUENTIAL ***
+
+bool shpynov_n_radix_sort_mpi::TestTaskSEQ::ValidationImpl() {
+  if (task_data->inputs_count[0] == 0) {
+    return false;
+  }
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool shpynov_n_radix_sort_mpi::TestTaskSEQ::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  result_ = std::vector<int>(output_size, 0);
+
+  return true;
+}
+
+bool shpynov_n_radix_sort_mpi::TestTaskSEQ::RunImpl() {
+  result_ = RadixSort(input_);
+
+  return true;
+}
+
+bool shpynov_n_radix_sort_mpi::TestTaskSEQ::PostProcessingImpl() {
+  auto *output = reinterpret_cast<int *>(task_data->outputs[0]);
+  std::ranges::copy(result_.begin(), result_.end(), output);
+  return true;
+}
+
+// *** PARALLEL ***
+
+bool shpynov_n_radix_sort_mpi::TestTaskMPI::ValidationImpl() {
+  if (world_.rank() == 0) {
+    if (task_data->inputs_count[0] == 0) {
+      return false;
+    }
+    return task_data->inputs_count[0] == task_data->outputs_count[0];
+  }
+  return true;
+}
+
+bool shpynov_n_radix_sort_mpi::TestTaskMPI::PreProcessingImpl() {
+  if (world_.rank() == 0) {
+    unsigned int input_size = task_data->inputs_count[0];
+    auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+    input_ = std::vector<int>(in_ptr, in_ptr + input_size);
+
+    unsigned int output_size = task_data->outputs_count[0];
+    result_ = std::vector<int>(output_size, 0);
+  }
+
+  return true;
+}
+
+bool shpynov_n_radix_sort_mpi::TestTaskMPI::RunImpl() {
+  size_t InVecSize = input_.size();
+  boost::mpi::broadcast(world_, InVecSize, 0);
+  std::vector<int> deltas(world_.size(), 0);
+  for (int procNum = 0; procNum < world_.size(); procNum++) {
+    deltas[procNum] = InVecSize / world_.size();
+  }
+  for (int i = 0; i < (static_cast<int>(InVecSize) % world_.size()); i++) {
+    deltas[i] += 1;
+  }
+  if (world_.rank() == 0) {
+    int deltas_sum = 0;
+    for (int procNum = 1; procNum < world_.size(); procNum++) {
+      deltas_sum += deltas[procNum - 1];
+      world_.send(procNum, 0, input_.data() + deltas_sum, deltas[procNum]);
+    }
+    std::vector<int> LocVec(input_.begin(), input_.begin() + deltas[0]);
+    RadixSort(LocVec);
+    result_ = std::move(LocVec);
+    for (int i = 1; i < world_.size(); i++) {
+      std::vector<int> RecievedSorted(deltas[i]);
+      world_.recv(i, 0, RecievedSorted.data(), deltas[i]);
+      std::vector<int> MergedPart(result_.size() + RecievedSorted.size());
+      std::merge(result_.begin(), result_.end(), RecievedSorted.begin(), RecievedSorted.end(), MergedPart.begin());
+      result_ = MergedPart;
+    }
+  } else {
+    std::vector<int> LocVec;
+    LocVec.resize((deltas[world_.rank()]));
+    world_.recv(0, 0, LocVec.data(), deltas[world_.rank()]);
+    RadixSort(LocVec);
+    world_.send(0, 0, LocVec.data(), deltas[world_.rank()]);
+  }
+
+  return true;
+}
+
+bool shpynov_n_radix_sort_mpi::TestTaskMPI::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    auto *output = reinterpret_cast<int *>(task_data->outputs[0]);
+    std::ranges::copy(result_.begin(), result_.end(), output);
+  }
+  return true;
+}

--- a/tasks/mpi/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort_mpi.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <boost/mpi/collectives.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
 #include <cmath>
 #include <cstddef>
 #include <utility>
@@ -69,7 +70,7 @@ bool shpynov_n_radix_sort_mpi::TestTaskMPI::RunImpl() {
   boost::mpi::broadcast(world_, in_vec_size, 0);
   std::vector<int> deltas(world_.size(), 0);
   for (int proc_num = 0; proc_num < world_.size(); proc_num++) {
-    deltas[proc_num] = in_vec_size / world_.size();
+    deltas[proc_num] = (unsigned int)in_vec_size / world_.size();
   }
   for (int i = 0; i < (static_cast<int>(in_vec_size) % world_.size()); i++) {
     deltas[i] += 1;
@@ -84,10 +85,10 @@ bool shpynov_n_radix_sort_mpi::TestTaskMPI::RunImpl() {
     RadixSort(loc_vec);
     result_ = std::move(loc_vec);
     for (int i = 1; i < world_.size(); i++) {
-      std::vector<int> RecievedSorted(deltas[i]);
-      world_.recv(i, 0, RecievedSorted.data(), deltas[i]);
-      std::vector<int> merged_part(result_.size() + RecievedSorted.size());
-      std::ranges::merge(result_.begin(), result_.end(), RecievedSorted.begin(), RecievedSorted.end(),
+      std::vector<int> recieved_sorted(deltas[i]);
+      world_.recv(i, 0, recieved_sorted.data(), deltas[i]);
+      std::vector<int> merged_part(result_.size() + recieved_sorted.size());
+      std::ranges::merge(result_.begin(), result_.end(), recieved_sorted.begin(), recieved_sorted.end(),
                          merged_part.begin());
       result_ = merged_part;
     }

--- a/tasks/mpi/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort_mpi.cpp
+++ b/tasks/mpi/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort_mpi.cpp
@@ -70,7 +70,7 @@ bool shpynov_n_radix_sort_mpi::TestTaskMPI::RunImpl() {
   boost::mpi::broadcast(world_, in_vec_size, 0);
   std::vector<int> deltas(world_.size(), 0);
   for (int proc_num = 0; proc_num < world_.size(); proc_num++) {
-    deltas[proc_num] = (unsigned int)in_vec_size / world_.size();
+    deltas[proc_num] = (int)in_vec_size / world_.size();
   }
   for (int i = 0; i < (static_cast<int>(in_vec_size) % world_.size()); i++) {
     deltas[i] += 1;

--- a/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -152,7 +153,7 @@ TEST(shpynov_n_radix_sort_seq, test_invalid) {
 TEST(shpynov_n_radix_sort_seq, test_random_number) {
   std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(1);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
@@ -173,7 +174,7 @@ TEST(shpynov_n_radix_sort_seq, test_random_number) {
 TEST(shpynov_n_radix_sort_seq, test_random_small_vector) {
   std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(20);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
@@ -194,7 +195,7 @@ TEST(shpynov_n_radix_sort_seq, test_random_small_vector) {
 TEST(shpynov_n_radix_sort_seq, test_random_big_vector) {
   std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(1000);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 

--- a/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp"
+
+TEST(shpynov_n_radix_sort_seq, test_single_num) {
+  std::vector<int> inputVec(1, 0);
+
+  std::vector<int> expected_result(1, 0);
+  std::vector<int> returned_result(1, 0);
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(1);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(1);
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_some_numbers) {
+  std::vector<int> inputVec = {17, 33, 22, 42};
+
+  std::vector<int> expected_result = {17, 22, 33, 42};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length) {
+  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659};
+
+  std::vector<int> expected_result = {0, 1, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_neg_numbers) {
+  std::vector<int> inputVec = {-17, -33, -22, -420, -1, -5837, -659};
+
+  std::vector<int> expected_result = {-5837, -659, -420, -33, -22, -17, -1};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers) {
+  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659, -4, -28, -76, -110291};
+
+  std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers_with_same_nums) {
+  std::vector<int> inputVec = {17, 33, 22, 420, 1, 17, 0, 5837, 659, -4, -28, 0, -76, -4, -110291};
+
+  std::vector<int> expected_result = {-110291, -76, -28, -4, -4, 0, 0, 1, 17, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+TEST(shpynov_n_radix_sort_seq, test_invalid) {
+  std::vector<int> inputVec;
+
+  std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_NE(test_task_seq.ValidationImpl(), true);
+}

--- a/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -8,13 +8,13 @@
 #include "seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp"
 
 TEST(shpynov_n_radix_sort_seq, test_single_num) {
-  std::vector<int> inputVec(1, 0);
+  std::vector<int> input_vec(1, 0);
 
   std::vector<int> expected_result(1, 0);
   std::vector<int> returned_result(1, 0);
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
   task_data_seq->inputs_count.emplace_back(1);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(1);
@@ -29,14 +29,14 @@ TEST(shpynov_n_radix_sort_seq, test_single_num) {
 }
 
 TEST(shpynov_n_radix_sort_seq, test_some_numbers) {
-  std::vector<int> inputVec = {17, 33, 22, 42};
+  std::vector<int> input_vec = {17, 33, 22, 42};
 
   std::vector<int> expected_result = {17, 22, 33, 42};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 
@@ -50,14 +50,14 @@ TEST(shpynov_n_radix_sort_seq, test_some_numbers) {
 }
 
 TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length) {
-  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659};
+  std::vector<int> input_vec = {17, 33, 22, 420, 1, 0, 5837, 659};
 
   std::vector<int> expected_result = {0, 1, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 
@@ -71,14 +71,14 @@ TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length) {
 }
 
 TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_neg_numbers) {
-  std::vector<int> inputVec = {-17, -33, -22, -420, -1, -5837, -659};
+  std::vector<int> input_vec = {-17, -33, -22, -420, -1, -5837, -659};
 
   std::vector<int> expected_result = {-5837, -659, -420, -33, -22, -17, -1};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 
@@ -92,14 +92,14 @@ TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_neg_numbers) {
 }
 
 TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers) {
-  std::vector<int> inputVec = {17, 33, 22, 420, 1, 0, 5837, 659, -4, -28, -76, -110291};
+  std::vector<int> input_vec = {17, 33, 22, 420, 1, 0, 5837, 659, -4, -28, -76, -110291};
 
   std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 
@@ -113,14 +113,14 @@ TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers
 }
 
 TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers_with_same_nums) {
-  std::vector<int> inputVec = {17, 33, 22, 420, 1, 17, 0, 5837, 659, -4, -28, 0, -76, -4, -110291};
+  std::vector<int> input_vec = {17, 33, 22, 420, 1, 17, 0, 5837, 659, -4, -28, 0, -76, -4, -110291};
 
   std::vector<int> expected_result = {-110291, -76, -28, -4, -4, 0, 0, 1, 17, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 
@@ -133,14 +133,14 @@ TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers
   ASSERT_EQ(expected_result, returned_result);
 }
 TEST(shpynov_n_radix_sort_seq, test_invalid) {
-  std::vector<int> inputVec;
+  std::vector<int> input_vec;
 
   std::vector<int> expected_result = {-110291, -76, -28, -4, 0, 1, 17, 22, 33, 420, 659, 5837};
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 

--- a/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/func_tests/main.cpp
@@ -132,6 +132,7 @@ TEST(shpynov_n_radix_sort_seq, test_some_numbers_diff_length_pos_and_neg_numbers
 
   ASSERT_EQ(expected_result, returned_result);
 }
+
 TEST(shpynov_n_radix_sort_seq, test_invalid) {
   std::vector<int> input_vec;
 
@@ -146,4 +147,67 @@ TEST(shpynov_n_radix_sort_seq, test_invalid) {
 
   shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
   ASSERT_NE(test_task_seq.ValidationImpl(), true);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_random_number) {
+  std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(1);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+  std::vector<int> returned_result(input_vec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_random_small_vector) {
+  std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(20);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+  std::vector<int> returned_result(input_vec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_random_big_vector) {
+  std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(1000);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+  std::vector<int> returned_result(input_vec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq(task_data_seq);
+  ASSERT_EQ(test_task_seq.ValidationImpl(), true);
+  test_task_seq.PreProcessingImpl();
+  test_task_seq.RunImpl();
+  test_task_seq.PostProcessingImpl();
+
+  ASSERT_EQ(expected_result, returned_result);
 }

--- a/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
+++ b/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -9,66 +11,64 @@
 namespace shpynov_n_radix_sort_seq {
 
 inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
-  int Max = 0;
-  for (int i = 0; i < vec.size(); i++) {
-    if (std::abs(vec[i]) > Max) {
-      Max = std::abs(vec[i]);
-    }
+  int maxNum = 0;
+  for (int i = 0; i < (int)vec.size(); i++) {
+    maxNum = std::max(std::abs(vec[i]), maxNum);
   }
   int count = 0;
-  while (Max) {
-    Max /= 10;
+  while (maxNum != 0) {
+    maxNum /= 10;
     count++;
   }
   return count;
 }
 
-inline std::vector<int> SortBySingleDigit(std::vector<int>& vec, int DigitPlace) {
+inline std::vector<int> SortBySingleDigit(std::vector<int>& vec, int digit_place) {
   std::vector<int> output(vec.size());
   std::vector<int> count(10, 0);
-  for (size_t i = 0; i < vec.size(); i++) {
-    count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10]++;
+  for (int i = 0; i < (int)vec.size(); i++) {
+    count[(vec[i] / (int)std::pow(10, digit_place)) % 10]++;
   }
   for (int i = 1; i < 10; i++) {
     count[i] += count[i - 1];
   }
-  for (int i = vec.size() - 1; i >= 0; i--) {
-    output[count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10] - 1] = vec[i];
-    count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10]--;
+  for (int i = (int)vec.size() - 1; i >= 0; i--) {
+    output[count[(vec[i] / (int)std::pow(10, digit_place)) % 10] - 1] = vec[i];
+    count[(vec[i] / (int)std::pow(10, digit_place)) % 10]--;
   }
-  for (int i = 0; i < vec.size(); i++) {
+  for (int i = 0; i < (int)vec.size(); i++) {
     vec[i] = output[i];
   }
   return output;
 }
 
 inline std::vector<int> RadixSort(std::vector<int>& vec) {
-  std::vector<int> vecPos;
-  std::vector<int> vecNeg;
-  int MaxPosNum = 0;
-  int MaxNegNum = 0;
-  for (int i = 0; i < vec.size(); i++) {
+  std::vector<int> vec_pos;
+  std::vector<int> vec_neg;
+  int max_pos_num = 0;
+  int max_neg_num = 0;
+  for (int i = 0; i < (int)vec.size(); i++) {
     if (vec[i] < 0) {
-      vecNeg.push_back(std::abs(vec[i]));
-      MaxNegNum = GetMaxAmountOfDigits(vecNeg);
+      vec_neg.push_back(std::abs(vec[i]));
+      max_neg_num = GetMaxAmountOfDigits(vec_neg);
     } else {
-      vecPos.push_back(vec[i]);
-      MaxPosNum = GetMaxAmountOfDigits(vecPos);
+      vec_pos.push_back(vec[i]);
+      max_pos_num = GetMaxAmountOfDigits(vec_pos);
     }
   }
-  for (int i = 0; i < MaxNegNum; i++) {
-    SortBySingleDigit(vecNeg, i);
+  for (int i = 0; i < max_neg_num; i++) {
+    SortBySingleDigit(vec_neg, i);
   }
-  std::reverse(vecNeg.begin(), vecNeg.end());
-  for (int i = 0; i < vecNeg.size(); i++) {
-    vecNeg[i] = -vecNeg[i];
+  std::ranges::reverse(vec_neg.begin(), vec_neg.end());
+  for (int i = 0; i < (int)vec_neg.size(); i++) {
+    vec_neg[i] = -vec_neg[i];
   }
-  for (int i = 0; i < MaxPosNum; i++) {
-    SortBySingleDigit(vecPos, i);
+  for (int i = 0; i < max_pos_num; i++) {
+    SortBySingleDigit(vec_pos, i);
   }
   vec.clear();
-  vec.insert(vec.end(), vecNeg.begin(), vecNeg.end());
-  vec.insert(vec.end(), vecPos.begin(), vecPos.end());
+  vec.insert(vec.end(), vec_neg.begin(), vec_neg.end());
+  vec.insert(vec.end(), vec_pos.begin(), vec_pos.end());
   return vec;
 }
 

--- a/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
+++ b/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
@@ -2,12 +2,23 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
+#include <ctime>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
 namespace shpynov_n_radix_sort_seq {
+
+inline std::vector<int> GetRandVec(int size) {
+  std::vector<int> vec(size);
+  std::srand(std::time({}));
+  for (int i = 0; i < size; ++i) {
+    vec[i] = static_cast<int>((std::rand() % 2000) - 1000);
+  }
+  return vec;
+}
 
 inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
   int max_num = 0;

--- a/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
+++ b/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -11,13 +10,13 @@
 namespace shpynov_n_radix_sort_seq {
 
 inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
-  int maxNum = 0;
+  int max_num = 0;
   for (int i = 0; i < (int)vec.size(); i++) {
-    maxNum = std::max(std::abs(vec[i]), maxNum);
+    max_num = std::max(std::abs(vec[i]), max_num);
   }
   int count = 0;
-  while (maxNum != 0) {
-    maxNum /= 10;
+  while (max_num != 0) {
+    max_num /= 10;
     count++;
   }
   return count;

--- a/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
+++ b/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
@@ -15,7 +15,7 @@ inline std::vector<int> GetRandVec(int size) {
   std::vector<int> vec(size);
   std::srand(std::time({}));
   for (int i = 0; i < size; ++i) {
-    vec[i] = static_cast<int>((std::rand() % 2000) - 1000);
+    vec[i] = (std::rand() % 2000) - 1000;
   }
   return vec;
 }

--- a/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
+++ b/tasks/seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace shpynov_n_radix_sort_seq {
+
+inline int GetMaxAmountOfDigits(std::vector<int>& vec) {
+  int Max = 0;
+  for (int i = 0; i < vec.size(); i++) {
+    if (std::abs(vec[i]) > Max) {
+      Max = std::abs(vec[i]);
+    }
+  }
+  int count = 0;
+  while (Max) {
+    Max /= 10;
+    count++;
+  }
+  return count;
+}
+
+inline std::vector<int> SortBySingleDigit(std::vector<int>& vec, int DigitPlace) {
+  std::vector<int> output(vec.size());
+  std::vector<int> count(10, 0);
+  for (size_t i = 0; i < vec.size(); i++) {
+    count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10]++;
+  }
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+  for (int i = vec.size() - 1; i >= 0; i--) {
+    output[count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10] - 1] = vec[i];
+    count[(vec[i] / (int)std::pow(10, DigitPlace)) % 10]--;
+  }
+  for (int i = 0; i < vec.size(); i++) {
+    vec[i] = output[i];
+  }
+  return output;
+}
+
+inline std::vector<int> RadixSort(std::vector<int>& vec) {
+  std::vector<int> vecPos;
+  std::vector<int> vecNeg;
+  int MaxPosNum = 0;
+  int MaxNegNum = 0;
+  for (int i = 0; i < vec.size(); i++) {
+    if (vec[i] < 0) {
+      vecNeg.push_back(std::abs(vec[i]));
+      MaxNegNum = GetMaxAmountOfDigits(vecNeg);
+    } else {
+      vecPos.push_back(vec[i]);
+      MaxPosNum = GetMaxAmountOfDigits(vecPos);
+    }
+  }
+  for (int i = 0; i < MaxNegNum; i++) {
+    SortBySingleDigit(vecNeg, i);
+  }
+  std::reverse(vecNeg.begin(), vecNeg.end());
+  for (int i = 0; i < vecNeg.size(); i++) {
+    vecNeg[i] = -vecNeg[i];
+  }
+  for (int i = 0; i < MaxPosNum; i++) {
+    SortBySingleDigit(vecPos, i);
+  }
+  vec.clear();
+  vec.insert(vec.end(), vecNeg.begin(), vecNeg.end());
+  vec.insert(vec.end(), vecPos.begin(), vecPos.end());
+  return vec;
+}
+
+class TestTaskSEQ : public ppc::core::Task {
+ public:
+  explicit TestTaskSEQ(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> result_;
+};
+
+}  // namespace shpynov_n_radix_sort_seq

--- a/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -10,13 +10,10 @@
 #include "seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp"
 
 TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
-  constexpr int kCount = 10;
-  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  for (int i = 0; i < kCount; i++) {
-    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
-    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
-  }
+  constexpr int kCount = 5000;
+  std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(kCount);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -29,7 +26,7 @@ TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
   auto test_task_seq = std::make_shared<shpynov_n_radix_sort_seq::TestTaskSEQ>(task_data_seq);
   shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq_1(task_data_seq);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 50;
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   perf_attr->current_timer = [&] {
@@ -49,14 +46,13 @@ TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
 }
 
 TEST(shpynov_n_radix_sort_seq, test_task_run) {
-  constexpr int kCount = 10;
-  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  for (int i = 0; i < kCount; i++) {
-    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
-    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
-  }
+  constexpr int kCount = 5000;
+  std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(kCount);
+  std::vector<int> expected_result = input_vec;
+  std::sort(expected_result.begin(), expected_result.end());
+
   std::vector<int> returned_result(input_vec.size());
+
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
@@ -67,7 +63,7 @@ TEST(shpynov_n_radix_sort_seq, test_task_run) {
   auto test_task_seq = std::make_shared<shpynov_n_radix_sort_seq::TestTaskSEQ>(task_data_seq);
   shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq_1(task_data_seq);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 50;
   const auto t0 = std::chrono::high_resolution_clock::now();
 
   perf_attr->current_timer = [&] {

--- a/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -13,7 +14,7 @@ TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
   constexpr int kCount = 5000;
   std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(kCount);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -49,7 +50,7 @@ TEST(shpynov_n_radix_sort_seq, test_task_run) {
   constexpr int kCount = 5000;
   std::vector<int> input_vec = shpynov_n_radix_sort_seq::GetRandVec(kCount);
   std::vector<int> expected_result = input_vec;
-  std::sort(expected_result.begin(), expected_result.end());
+  std::ranges::sort(expected_result.begin(), expected_result.end());
 
   std::vector<int> returned_result(input_vec.size());
 

--- a/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp"
+
+TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
+  constexpr int kCount = 10;
+  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  for (int i = 0; i < kCount; i++) {
+    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
+  }
+
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  auto test_task_seq = std::make_shared<shpynov_n_radix_sort_seq::TestTaskSEQ>(task_data_seq);
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq_1(task_data_seq);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_seq);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  // Create Perf analyzer
+
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected_result, returned_result);
+}
+
+TEST(shpynov_n_radix_sort_seq, test_task_run) {
+  constexpr int kCount = 10;
+  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  for (int i = 0; i < kCount; i++) {
+    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
+  }
+  std::vector<int> returned_result(inputVec.size());
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
+  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
+  task_data_seq->outputs_count.emplace_back(returned_result.size());
+
+  auto test_task_seq = std::make_shared<shpynov_n_radix_sort_seq::TestTaskSEQ>(task_data_seq);
+  shpynov_n_radix_sort_seq::TestTaskSEQ test_task_seq_1(task_data_seq);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_seq);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  // Create Perf analyzer
+
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected_result, returned_result);
+}

--- a/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/perf_tests/main.cpp
@@ -1,25 +1,28 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
 #include "seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp"
 
 TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
   constexpr int kCount = 10;
-  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   for (int i = 0; i < kCount; i++) {
-    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
     expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
   }
 
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 
@@ -47,17 +50,17 @@ TEST(shpynov_n_radix_sort_seq, test_pipeline_run) {
 
 TEST(shpynov_n_radix_sort_seq, test_task_run) {
   constexpr int kCount = 10;
-  std::vector<int> inputVec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> input_vec = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   std::vector<int> expected_result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   for (int i = 0; i < kCount; i++) {
-    inputVec.insert(inputVec.end(), inputVec.begin(), inputVec.end());
+    input_vec.insert(input_vec.end(), input_vec.begin(), input_vec.end());
     expected_result.insert(expected_result.end(), expected_result.begin(), expected_result.end());
   }
-  std::vector<int> returned_result(inputVec.size());
+  std::vector<int> returned_result(input_vec.size());
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(inputVec.data()));
-  task_data_seq->inputs_count.emplace_back(inputVec.size());
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_vec.data()));
+  task_data_seq->inputs_count.emplace_back(input_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(returned_result.data()));
   task_data_seq->outputs_count.emplace_back(returned_result.size());
 

--- a/tasks/seq/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <vector>
 
 bool shpynov_n_radix_sort_seq::TestTaskSEQ::ValidationImpl() {

--- a/tasks/seq/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort.cpp
+++ b/tasks/seq/Shpynov_N_radix_sort/src/Shpynov_N_radix_sort.cpp
@@ -1,0 +1,36 @@
+#include "seq/Shpynov_N_radix_sort/include/Shpynov_N_radix_sort.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+bool shpynov_n_radix_sort_seq::TestTaskSEQ::ValidationImpl() {
+  if (task_data->inputs_count[0] == 0) {
+    return false;
+  }
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool shpynov_n_radix_sort_seq::TestTaskSEQ::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  result_ = std::vector<int>(output_size, 0);
+
+  return true;
+}
+
+bool shpynov_n_radix_sort_seq::TestTaskSEQ::RunImpl() {
+  result_ = RadixSort(input_);
+
+  return true;
+}
+
+bool shpynov_n_radix_sort_seq::TestTaskSEQ::PostProcessingImpl() {
+  auto *output = reinterpret_cast<int *>(task_data->outputs[0]);
+  std::ranges::copy(result_.begin(), result_.end(), output);
+  return true;
+}


### PR DESCRIPTION
Поразрядная сортировка для целых чисел с простым слиянием.

Сортировка с линейным временем. Осуществляется для вектора целых чисел следующим образом: 

Сначала сравниваются значения последнего разряда всех чисел, и элементы группируются по результатам этого сравнения. Затем сравниваются значения следующего разряда, и элементы переупорядочиваются, сохраняя относительный порядок, достигнутый при предыдущей сортировке. Этот процесс повторяется для каждого разряда.

---

По такой логике и работает последовательная версия.  

Реализованы функции ```SortBySingleDigit``` - одновременная сортировка массива на основе заданного разряда, а также ```RadixSort``` - считает максимальное количество разрядов и вызывает ```SortBySingleDigit``` для каждого. Поскольку классическая реализация ```SortBySingleDigit``` не работает с отрицательными числами, для них  производится отдельная сортировка (сортируются их модули в обратном порядке), после чего они возвращаются в основной массив чисел. Таким образом, на вход подается вектор int'ов, он же и сортируется.

---

Отличие параллельной версии в том, что сначала высчитывается длина подмассива для каждого потока (случаи некратности длины вектора количеству потоков и превосходства их числа над его длинной учтены), после чего, полученный вектор делится и его части отправляется потокам. 

Каждый поток, в том числе и мастер, вызывает ```RadixSort``` для своего подмассива и возвращает уже отсортированный. После этого, главный поток с помощью ```std::merge``` соединяет все полученные результаты в один вектор и возвращает его.