### PR TITLE
Константинов Илья. Задача 3. Вариант 30. Повышение контраста полутонового изображения посредством  линейной растяжки гистограммы.

### DIFF
--- a/tasks/mpi/Konstantinov_I_histogram_stretching/func_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/func_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <algorithm>
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/environment.hpp>
@@ -21,7 +22,6 @@ std::vector<int> GetRandomImage(int sz) {
 }
 }  // namespace
 }  // namespace konstantinov_i_linear_histogram_stretch_mpi
-
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_image_imin_imax) {
   boost::mpi::communicator world;

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/func_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/func_tests/main.cpp
@@ -1,9 +1,8 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <boost/mpi/communicator.hpp>
-#include <boost/mpi/environment.hpp>
-#include <functional>
+#include <cstdint>
+#include <memory>
 #include <random>
 #include <vector>
 
@@ -25,41 +24,33 @@ std::vector<int> GetRandomImage(int sz) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_image_imin_imax) {
   boost::mpi::communicator world;
-
   const int count_size_vector = 9;
   std::vector<int> in_vec = {255, 100, 25, 255, 100, 25, 255, 100, 25};
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
   ASSERT_EQ(test_mpi.ValidationImpl(), true);
   test_mpi.PreProcessingImpl();
   test_mpi.RunImpl();
   test_mpi.PostProcessingImpl();
-
   if (world.rank() == 0) {
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, in_vec);
     ASSERT_EQ(out_vec_seq, in_vec);
     ASSERT_EQ(out_vec_par, out_vec_seq);
@@ -68,228 +59,185 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_image_imin_imax) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_correct_image) {
   boost::mpi::communicator world;
-
   const int width = 150;
   const int height = 150;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
   ASSERT_EQ(test_mpi.ValidationImpl(), true);
   test_mpi.PreProcessingImpl();
   test_mpi.RunImpl();
   test_mpi.PostProcessingImpl();
-
   if (world.rank() == 0) {
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_large_image) {
   boost::mpi::communicator world;
-
   const int width = 422;
   const int height = 763;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
   ASSERT_EQ(test_mpi.ValidationImpl(), true);
   test_mpi.PreProcessingImpl();
   test_mpi.RunImpl();
   test_mpi.PostProcessingImpl();
-
   if (world.rank() == 0) {
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_large_image2) {
   boost::mpi::communicator world;
-
   const int width = 1024;
   const int height = 512;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
   ASSERT_EQ(test_mpi.ValidationImpl(), true);
   test_mpi.PreProcessingImpl();
   test_mpi.RunImpl();
   test_mpi.PostProcessingImpl();
-
   if (world.rank() == 0) {
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_large_square_image) {
   boost::mpi::communicator world;
-
   const int width = 680;
   const int height = 680;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
   ASSERT_EQ(test_mpi.ValidationImpl(), true);
   test_mpi.PreProcessingImpl();
   test_mpi.RunImpl();
   test_mpi.PostProcessingImpl();
-
   if (world.rank() == 0) {
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_small_square_image) {
   boost::mpi::communicator world;
-
   const int width = 64;
   const int height = 64;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
   ASSERT_EQ(test_mpi.ValidationImpl(), true);
   test_mpi.PreProcessingImpl();
   test_mpi.RunImpl();
   test_mpi.PostProcessingImpl();
-
   if (world.rank() == 0) {
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_image_size) {
   boost::mpi::communicator world;
-
   const int count_size_vector = 5;
   std::vector<int> in_vec = {0, 20, 30, 0, 40};
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
@@ -302,15 +250,12 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_image_size) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image) {
   boost::mpi::communicator world;
-
   const int width = 3;
   const int height = 3;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = {-2, 20, 30, 0, 355, -25, 10, 260, 255};
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
@@ -323,15 +268,12 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image2) {
   boost::mpi::communicator world;
-
   const int width = 2;
   const int height = 3;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = {-2, 20, 30, 0, 355, -25, 10, 260, 255, -2, 20, 30, 22, 33, 44, 72, 89, 90};
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
@@ -344,7 +286,6 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image2) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image3) {
   boost::mpi::communicator world;
-
   const int width = 70;
   const int height = 15;
   const int count_size_vector = width * height * 3;
@@ -352,9 +293,7 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image3) {
   in_vec[5] = -25;
   in_vec[17] = 266;
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());
@@ -367,15 +306,12 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image3) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_empty_image) {
   boost::mpi::communicator world;
-
   const int width = 0;
   const int height = 0;
   const int count_size_vector = width * height * 3;
   std::vector<int> in_vec = {};
   std::vector<int> out_vec_par(count_size_vector, 0);
-
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_par->inputs_count.emplace_back(in_vec.size());

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/func_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/func_tests/main.cpp
@@ -1,0 +1,387 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
+
+namespace konstantinov_i_linear_histogram_stretch_mpi {
+namespace {
+std::vector<int> GetRandomImage(int sz) {
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  std::vector<int> vec(sz);
+  for (int i = 0; i < sz; i++) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+}  // namespace
+}  // namespace konstantinov_i_linear_histogram_stretch_mpi
+
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_image_imin_imax) {
+  boost::mpi::communicator world;
+
+  const int count_size_vector = 9;
+  std::vector<int> in_vec = {255, 100, 25, 255, 100, 25, 255, 100, 25};
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+  ASSERT_EQ(test_mpi.ValidationImpl(), true);
+  test_mpi.PreProcessingImpl();
+  test_mpi.RunImpl();
+  test_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, in_vec);
+    ASSERT_EQ(out_vec_seq, in_vec);
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_correct_image) {
+  boost::mpi::communicator world;
+
+  const int width = 150;
+  const int height = 150;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+  ASSERT_EQ(test_mpi.ValidationImpl(), true);
+  test_mpi.PreProcessingImpl();
+  test_mpi.RunImpl();
+  test_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_large_image) {
+  boost::mpi::communicator world;
+
+  const int width = 422;
+  const int height = 763;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+  ASSERT_EQ(test_mpi.ValidationImpl(), true);
+  test_mpi.PreProcessingImpl();
+  test_mpi.RunImpl();
+  test_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_large_image2) {
+  boost::mpi::communicator world;
+
+  const int width = 1024;
+  const int height = 512;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+  ASSERT_EQ(test_mpi.ValidationImpl(), true);
+  test_mpi.PreProcessingImpl();
+  test_mpi.RunImpl();
+  test_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_large_square_image) {
+  boost::mpi::communicator world;
+
+  const int width = 680;
+  const int height = 680;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+  ASSERT_EQ(test_mpi.ValidationImpl(), true);
+  test_mpi.PreProcessingImpl();
+  test_mpi.RunImpl();
+  test_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_small_square_image) {
+  boost::mpi::communicator world;
+
+  const int width = 64;
+  const int height = 64;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+  ASSERT_EQ(test_mpi.ValidationImpl(), true);
+  test_mpi.PreProcessingImpl();
+  test_mpi.RunImpl();
+  test_mpi.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_image_size) {
+  boost::mpi::communicator world;
+
+  const int count_size_vector = 5;
+  std::vector<int> in_vec = {0, 20, 30, 0, 40};
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+    ASSERT_EQ(test_mpi.ValidationImpl(), false);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image) {
+  boost::mpi::communicator world;
+
+  const int width = 3;
+  const int height = 3;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = {-2, 20, 30, 0, 355, -25, 10, 260, 255};
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+    ASSERT_EQ(test_mpi.ValidationImpl(), false);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image2) {
+  boost::mpi::communicator world;
+
+  const int width = 2;
+  const int height = 3;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = {-2, 20, 30, 0, 355, -25, 10, 260, 255, -2, 20, 30, 22, 33, 44, 72, 89, 90};
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+    ASSERT_EQ(test_mpi.ValidationImpl(), false);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_rgb_image3) {
+  boost::mpi::communicator world;
+
+  const int width = 70;
+  const int height = 15;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+  in_vec[5] = -25;
+  in_vec[17] = 266;
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+    ASSERT_EQ(test_mpi.ValidationImpl(), false);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_incorrect_empty_image) {
+  boost::mpi::communicator world;
+
+  const int width = 0;
+  const int height = 0;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> in_vec = {};
+  std::vector<int> out_vec_par(count_size_vector, 0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi test_mpi(task_data_par);
+    ASSERT_EQ(test_mpi.ValidationImpl(), false);
+  }
+}

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace konstantinov_i_linear_histogram_stretch_mpi {
+
+class LinearHistogramStretchSeq : public ppc::core::Task {
+ public:
+  explicit LinearHistogramStretchSeq(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> I;
+  std::vector<int> image_input;
+  std::vector<int> image_output;
+};
+
+class LinearHistogramStretchMpi : public ppc::core::Task {
+ public:
+  explicit LinearHistogramStretchMpi(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> image_input;
+  std::vector<int> image_output;
+  boost::mpi::communicator world;
+};
+}  // namespace konstantinov_i_linear_histogram_stretch_mpi

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp
@@ -3,8 +3,6 @@
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <memory>
-#include <numeric>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -21,9 +19,9 @@ class LinearHistogramStretchSeq : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<int> I;
-  std::vector<int> image_input;
-  std::vector<int> image_output;
+  std::vector<int> I_;
+  std::vector<int> image_input_;
+  std::vector<int> image_output_;
 };
 
 class LinearHistogramStretchMpi : public ppc::core::Task {
@@ -35,8 +33,8 @@ class LinearHistogramStretchMpi : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<int> image_input;
-  std::vector<int> image_output;
-  boost::mpi::communicator world;
+  std::vector<int> image_input_;
+  std::vector<int> image_output_;
+  boost::mpi::communicator world_;
 };
 }  // namespace konstantinov_i_linear_histogram_stretch_mpi

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -2,10 +2,10 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/timer.hpp>
-#include <functional>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <random>
 #include <vector>

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -3,6 +3,10 @@
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/timer.hpp>
 #include <functional>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
 #include <random>
 #include <vector>
 

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+#include <boost/mpi/timer.hpp>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
+
+namespace konstantinov_i_linear_histogram_stretch_mpi {
+namespace {
+std::vector<int> GetRandomImage(int sz) {
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  std::vector<int> vec(sz);
+  for (int i = 0; i < sz; i++) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+}  // namespace
+}  // namespace konstantinov_i_linear_histogram_stretch_mpi
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_pipeline_run) {
+  boost::mpi::communicator world;
+
+  const int width = 3550;
+  const int height = 3550;
+
+  std::vector<int> in_vec;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> out_vec_par(count_size_vector, 0);
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  auto test_mpi =
+      std::make_shared<konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi>(task_data_par);
+  ASSERT_EQ(test_mpi->ValidationImpl(), true);
+  test_mpi->PreProcessingImpl();
+  test_mpi->RunImpl();
+  test_mpi->PostProcessingImpl();
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perf_attr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_mpi);
+  perf_analyzer->PipelineRun(perf_attr, perf_results );
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results );
+
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_task_run) {
+  boost::mpi::communicator world;
+
+  const int width = 3550;
+  const int height = 3550;
+
+  std::vector<int> in_vec;
+  const int count_size_vector = width * height * 3;
+  std::vector<int> out_vec_par(count_size_vector, 0);
+  std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_par->inputs_count.emplace_back(in_vec.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
+    task_data_par->outputs_count.emplace_back(out_vec_par.size());
+  }
+
+  auto test_mpi =
+      std::make_shared<konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi>(task_data_par);
+  ASSERT_EQ(test_mpi->ValidationImpl(), true);
+  test_mpi->PreProcessingImpl();
+  test_mpi->RunImpl();
+  test_mpi->PostProcessingImpl();
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const boost::mpi::timer current_timer;
+  perf_attr->current_timer = [&] { return current_timer.elapsed(); };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_mpi);
+  perf_analyzer->TaskRun(perf_attr, perf_results );
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results );
+
+    std::vector<int> out_vec_seq(count_size_vector, 0);
+
+    std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+    task_data_seq->inputs_count.emplace_back(in_vec.size());
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
+    task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
+
+    konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
+    ASSERT_EQ(test_seq.ValidationImpl(), true);
+    test_seq.PreProcessingImpl();
+    test_seq.RunImpl();
+    test_seq.PostProcessingImpl();
+
+    ASSERT_EQ(out_vec_par, out_vec_seq);
+  }
+}

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <boost/mpi/timer.hpp>
 #include <functional>
 #include <random>
@@ -55,9 +56,9 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_pipeline_run) {
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_mpi);
-  perf_analyzer->PipelineRun(perf_attr, perf_results );
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
   if (world.rank() == 0) {
-    ppc::core::Perf::PrintPerfStatistic(perf_results );
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
 
     std::vector<int> out_vec_seq(count_size_vector, 0);
 
@@ -111,9 +112,9 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_task_run) {
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_mpi);
-  perf_analyzer->TaskRun(perf_attr, perf_results );
+  perf_analyzer->TaskRun(perf_attr, perf_results);
   if (world.rank() == 0) {
-    ppc::core::Perf::PrintPerfStatistic(perf_results );
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
 
     std::vector<int> out_vec_seq(count_size_vector, 0);
 

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -2,7 +2,6 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/timer.hpp>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
@@ -30,15 +29,12 @@ std::vector<int> GetRandomImage(int sz) {
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_pipeline_run) {
   boost::mpi::communicator world;
-
   const int width = 3550;
   const int height = 3550;
-
   std::vector<int> in_vec;
   const int count_size_vector = width * height * 3;
   std::vector<int> out_vec_par(count_size_vector, 0);
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
@@ -46,55 +42,44 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_pipeline_run) {
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   auto test_mpi =
       std::make_shared<konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi>(task_data_par);
   ASSERT_EQ(test_mpi->ValidationImpl(), true);
   test_mpi->PreProcessingImpl();
   test_mpi->RunImpl();
   test_mpi->PostProcessingImpl();
-
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const boost::mpi::timer current_timer;
   perf_attr->current_timer = [&] { return current_timer.elapsed(); };
-
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
-
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_mpi);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
-
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }
 
 TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_task_run) {
   boost::mpi::communicator world;
-
   const int width = 3550;
   const int height = 3550;
-
   std::vector<int> in_vec;
   const int count_size_vector = width * height * 3;
   std::vector<int> out_vec_par(count_size_vector, 0);
   std::shared_ptr<ppc::core::TaskData> task_data_par = std::make_shared<ppc::core::TaskData>();
-
   if (world.rank() == 0) {
     in_vec = konstantinov_i_linear_histogram_stretch_mpi::GetRandomImage(count_size_vector);
     task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
@@ -102,40 +87,32 @@ TEST(Konstantinov_i_linear_histogram_stretch_mpi, test_task_run) {
     task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_par.data()));
     task_data_par->outputs_count.emplace_back(out_vec_par.size());
   }
-
   auto test_mpi =
       std::make_shared<konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi>(task_data_par);
   ASSERT_EQ(test_mpi->ValidationImpl(), true);
   test_mpi->PreProcessingImpl();
   test_mpi->RunImpl();
   test_mpi->PostProcessingImpl();
-
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const boost::mpi::timer current_timer;
   perf_attr->current_timer = [&] { return current_timer.elapsed(); };
-
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
-
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_mpi);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
-
     std::vector<int> out_vec_seq(count_size_vector, 0);
-
     std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
     task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
     task_data_seq->inputs_count.emplace_back(in_vec.size());
     task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec_seq.data()));
     task_data_seq->outputs_count.emplace_back(out_vec_seq.size());
-
     konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq test_seq(task_data_seq);
     ASSERT_EQ(test_seq.ValidationImpl(), true);
     test_seq.PreProcessingImpl();
     test_seq.RunImpl();
     test_seq.PostProcessingImpl();
-
     ASSERT_EQ(out_vec_par, out_vec_seq);
   }
 }

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -1,11 +1,13 @@
 #include <gtest/gtest.h>
 
+#include <boost/mpi/communicator.hpp>
 #include <boost/mpi/timer.hpp>
 #include <functional>
 #include <random>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
 #include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
 
 namespace konstantinov_i_linear_histogram_stretch_mpi {

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -1,8 +1,8 @@
 #include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
 
 #include <algorithm>
-#include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/all_reduce.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/scatterv.hpp>
 #include <vector>
 

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -5,6 +5,7 @@
 #include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/gatherv.hpp>
 #include <boost/mpi/collectives/scatterv.hpp>
+#include <boost/mpi/operations.hpp>
 #include <vector>
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PreProcessingImpl() {

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <boost/mpi/collectives/all_reduce.hpp>
 #include <boost/mpi/collectives/broadcast.hpp>
-#include <boost/mpi/collectives/scatterv.hpp>
 #include <boost/mpi/collectives/gatherv.hpp>
+#include <boost/mpi/collectives/scatterv.hpp>
 #include <vector>
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PreProcessingImpl() {

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -1,34 +1,37 @@
 #include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
 
-#include <string>
-#include <thread>
+#include <algorithm>
+#include <boost/mpi/collectives/broadcast.hpp>
+#include <boost/mpi/collectives/all_reduce.hpp>
+#include <boost/mpi/collectives/scatterv.hpp>
 #include <vector>
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PreProcessingImpl() {
-  int size = task_data->inputs_count[0];
-  image_input = std::vector<int>(size);
+  int size = static_cast<int>(task_data->inputs_count[0]);
+  image_input_ = std::vector<int>(size);
   auto* tmp_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
-  std::copy(tmp_ptr, tmp_ptr + size, image_input.begin());
+  std::copy(tmp_ptr, tmp_ptr + size, image_input_.begin());
 
   int pixel_count = size / 3;
-  I.resize(pixel_count);
+  I_.resize(pixel_count);
   for (int i = 0, k = 0; i < size; i += 3, ++k) {
-    int r = image_input[i];
-    int g = image_input[i + 1];
-    int b = image_input[i + 2];
+    int r = image_input_[i];
+    int g = image_input_[i + 1];
+    int b = image_input_[i + 2];
 
-    I[k] = static_cast<int>(0.299 * static_cast<double>(r) + 0.587 * static_cast<double>(g) +
-                            0.114 * static_cast<double>(b));
+    I_[k] = static_cast<int>((0.299 * static_cast<double>(r)) + (0.587 * static_cast<double>(g)) +
+                             (0.114 * static_cast<double>(b)));
   }
 
-  image_output = {};
+  image_output_ = {};
   return true;
 }
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::ValidationImpl() {
-  int size = task_data->inputs_count[0];
-  if (size % 3 != 0) return false;
-
+  int size = static_cast<int>(task_data->inputs_count[0]);
+  if (size % 3 != 0) {
+    return false;
+  }
   for (int i = 0; i < size; ++i) {
     int value = reinterpret_cast<int*>(task_data->inputs[0])[i];
     if (value < 0 || value > 255) {
@@ -42,29 +45,29 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::Val
 }
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::RunImpl() {
-  int size = image_input.size();
-  image_output.resize(size);
-  int Imin = 255;
-  int Imax = 0;
+  int size = static_cast<int>(image_input_.size());
+  image_output_.resize(size);
+  int imin = 255;
+  int imax = 0;
 
-  for (int intensity : I) {
-    Imin = std::min(Imin, intensity);
-    Imax = std::max(Imax, intensity);
+  for (int intensity : I_) {
+    imin = std::min(imin, intensity);
+    imax = std::max(imax, intensity);
   }
 
-  if (Imin == Imax) {
-    image_output = image_input;
+  if (imin == imax) {
+    image_output_ = image_input_;
     return true;
   }
 
   for (int i = 0, k = 0; i < size; i += 3, ++k) {
-    int Inew = ((I[k] - Imin) * 255) / (Imax - Imin);
+    int inew = ((I_[k] - imin) * 255) / (imax - imin);
 
-    float coeff = static_cast<float>(Inew) / static_cast<float>(I[k]);
+    float coeff = static_cast<float>(inew) / static_cast<float>(I_[k]);
 
-    image_output[i] = std::min(255, static_cast<int>(image_input[i] * coeff));
-    image_output[i + 1] = std::min(255, static_cast<int>(image_input[i + 1] * coeff));
-    image_output[i + 2] = std::min(255, static_cast<int>(image_input[i + 2] * coeff));
+    image_output_[i] = std::min(255, static_cast<int>(image_input_[i] * coeff));
+    image_output_[i + 1] = std::min(255, static_cast<int>(image_input_[i + 1] * coeff));
+    image_output_[i + 2] = std::min(255, static_cast<int>(image_input_[i + 2] * coeff));
   }
 
   return true;
@@ -72,27 +75,28 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::Run
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PostProcessingImpl() {
   auto* output = reinterpret_cast<int*>(task_data->outputs[0]);
-  std::copy(image_output.begin(), image_output.end(), output);
+  std::ranges::copy(image_output_, output);
   return true;
 }
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::PreProcessingImpl() {
-  if (world.rank() == 0) {
-    int size = task_data->inputs_count[0];
-    image_input = std::vector<int>(size);
+  if (world_.rank() == 0) {
+    int size = static_cast<int>(task_data->inputs_count[0]);
+    image_input_ = std::vector<int>(size);
     auto* tmp_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
-    std::copy(tmp_ptr, tmp_ptr + size, image_input.begin());
-    image_output = {};
+    std::copy(tmp_ptr, tmp_ptr + size, image_input_.begin());
+    image_output_ = {};
     return true;
   }
   return true;
 }
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::ValidationImpl() {
-  if (world.rank() == 0) {
-    int size = task_data->inputs_count[0];
-    if (size % 3 != 0) return false;
-
+  if (world_.rank() == 0) {
+    int size = static_cast<float>(task_data->inputs_count[0]);
+    if (size % 3 != 0) {
+      return false;
+    }
     for (int i = 0; i < size; ++i) {
       int value = reinterpret_cast<int*>(task_data->inputs[0])[i];
       if (value < 0 || value > 255) {
@@ -109,32 +113,32 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::Val
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::RunImpl() {
   int size = 0;
-  if (world.rank() == 0) {
-    size = image_input.size();
+  if (world_.rank() == 0) {
+    size = static_cast<int>(image_input_.size());
   }
 
-  broadcast(world, size, 0);
+  boost::mpi::broadcast(world_, size, 0);
 
   int num_pixels = 0;
   int pixels_per_process = 0;
   int extra_pixels = 0;
-  if (world.rank() == 0) {
+  if (world_.rank() == 0) {
     num_pixels = size / 3;
-    pixels_per_process = num_pixels / world.size();
-    extra_pixels = num_pixels % world.size();
+    pixels_per_process = num_pixels / world_.size();
+    extra_pixels = num_pixels % world_.size();
   }
 
-  broadcast(world, num_pixels, 0);
-  broadcast(world, pixels_per_process, 0);
-  broadcast(world, extra_pixels, 0);
+  boost::mpi::broadcast(world_, num_pixels, 0);
+  boost::mpi::broadcast(world_, pixels_per_process, 0);
+  boost::mpi::broadcast(world_, extra_pixels, 0);
 
-  int local_pixels = pixels_per_process + (world.rank() < extra_pixels ? 1 : 0);
+  int local_pixels = pixels_per_process + (world_.rank() < extra_pixels ? 1 : 0);
 
-  std::vector<int> offset(world.size(), 0);
-  std::vector<int> send_counts(world.size(), 0);
+  std::vector<int> offset(world_.size(), 0);
+  std::vector<int> send_counts(world_.size(), 0);
 
-  if (world.rank() == 0) {
-    for (int proc = 0; proc < world.size(); ++proc) {
+  if (world_.rank() == 0) {
+    for (int proc = 0; proc < world_.size(); ++proc) {
       send_counts[proc] = (pixels_per_process + (proc < extra_pixels ? 1 : 0)) * 3;
       if (proc > 0) {
         offset[proc] = offset[proc - 1] + send_counts[proc - 1];
@@ -142,61 +146,61 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::Run
     }
   }
 
-  broadcast(world, send_counts.data(), send_counts.size(), 0);
-  broadcast(world, offset.data(), offset.size(), 0);
+  boost::mpi::broadcast(world_, send_counts.data(), static_cast<int>(send_counts.size()), 0);
+  boost::mpi::broadcast(world_, offset.data(), static_cast<int>(offset.size()), 0);
 
   std::vector<int> local_input(local_pixels * 3);
-  boost::mpi::scatterv(world, image_input.data(), send_counts, offset, local_input.data(), local_pixels * 3, 0);
+  boost::mpi::scatterv(world_, image_input_.data(), send_counts, offset, local_input.data(), local_pixels * 3, 0);
 
-  int local_Imin = 255;
-  int local_Imax = 0;
-  std::vector<int> local_I(local_pixels);
+  int local_imin = 255;
+  int local_imax = 0;
+  std::vector<int> local_i(local_pixels);
   for (int i = 0, k = 0; i < local_pixels * 3; i += 3, ++k) {
-    int R = local_input[i];
-    int G = local_input[i + 1];
-    int B = local_input[i + 2];
+    int r = local_input[i];
+    int g = local_input[i + 1];
+    int b = local_input[i + 2];
 
-    local_I[k] = static_cast<int>(0.299 * static_cast<double>(R) + 0.587 * static_cast<double>(G) +
-                                  0.114 * static_cast<double>(B));
-    local_Imin = std::min(local_Imin, local_I[k]);
-    local_Imax = std::max(local_Imax, local_I[k]);
+    local_i[k] = static_cast<int>((0.299 * static_cast<double>(r)) + (0.587 * static_cast<double>(g)) +
+                                  (0.114 * static_cast<double>(b)));
+    local_imin = std::min(local_imin, local_i[k]);
+    local_imax = std::max(local_imax, local_i[k]);
   }
 
-  int global_Imin;
-  int global_Imax;
-  boost::mpi::all_reduce(world, local_Imin, global_Imin, boost::mpi::minimum<int>());
-  boost::mpi::all_reduce(world, local_Imax, global_Imax, boost::mpi::maximum<int>());
+  int global_imin = 0;
+  int global_imax = 0;
+  boost::mpi::all_reduce(world_, local_imin, global_imin, boost::mpi::minimum<int>());
+  boost::mpi::all_reduce(world_, local_imax, global_imax, boost::mpi::maximum<int>());
 
-  if (global_Imin == global_Imax) {
-    if (world.rank() == 0) {
-      image_output = image_input;
+  if (global_imin == global_imax) {
+    if (world_.rank() == 0) {
+      image_output_ = image_input_;
     }
     return true;
   }
 
   std::vector<int> local_output(local_pixels * 3);
   for (int i = 0, k = 0; i < local_pixels * 3; i += 3, ++k) {
-    int Inew = ((local_I[k] - global_Imin) * 255) / (global_Imax - global_Imin);
-    float coeff = static_cast<float>(Inew) / static_cast<float>(local_I[k]);
+    int inew = ((local_i[k] - global_imin) * 255) / (global_imax - global_imin);
+    float coeff = static_cast<float>(inew) / static_cast<float>(local_i[k]);
 
     local_output[i] = std::min(255, static_cast<int>(local_input[i] * coeff));
     local_output[i + 1] = std::min(255, static_cast<int>(local_input[i + 1] * coeff));
     local_output[i + 2] = std::min(255, static_cast<int>(local_input[i + 2] * coeff));
   }
 
-  if (world.rank() == 0) {
-    image_output.resize(size);
+  if (world_.rank() == 0) {
+    image_output_.resize(size);
   }
 
-  boost::mpi::gatherv(world, local_output.data(), local_pixels * 3, image_output.data(), send_counts, offset, 0);
+  boost::mpi::gatherv(world_, local_output.data(), local_pixels * 3, image_output_.data(), send_counts, offset, 0);
 
   return true;
 }
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::PostProcessingImpl() {
-  if (world.rank() == 0) {
+  if (world_.rank() == 0) {
     auto* output = reinterpret_cast<int*>(task_data->outputs[0]);
-    std::copy(image_output.begin(), image_output.end(), output);
+    std::ranges::copy(image_output_, output);
   }
   return true;
 }

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -1,4 +1,5 @@
 #include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
+
 #include <string>
 #include <thread>
 #include <vector>

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -1,0 +1,201 @@
+#include "mpi/Konstantinov_I_histogram_stretching/include/ops_mpi.hpp"
+#include <string>
+#include <thread>
+#include <vector>
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PreProcessingImpl() {
+  int size = task_data->inputs_count[0];
+  image_input = std::vector<int>(size);
+  auto* tmp_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + size, image_input.begin());
+
+  int pixel_count = size / 3;
+  I.resize(pixel_count);
+  for (int i = 0, k = 0; i < size; i += 3, ++k) {
+    int r = image_input[i];
+    int g = image_input[i + 1];
+    int b = image_input[i + 2];
+
+    I[k] = static_cast<int>(0.299 * static_cast<double>(r) + 0.587 * static_cast<double>(g) +
+                            0.114 * static_cast<double>(b));
+  }
+
+  image_output = {};
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::ValidationImpl() {
+  int size = task_data->inputs_count[0];
+  if (size % 3 != 0) return false;
+
+  for (int i = 0; i < size; ++i) {
+    int value = reinterpret_cast<int*>(task_data->inputs[0])[i];
+    if (value < 0 || value > 255) {
+      return false;
+    }
+  }
+
+  return ((!task_data->inputs.empty() && !task_data->outputs.empty()) &&
+          (!task_data->inputs_count.empty() && task_data->inputs_count[0] != 0) &&
+          (!task_data->outputs_count.empty() && task_data->outputs_count[0] != 0));
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::RunImpl() {
+  int size = image_input.size();
+  image_output.resize(size);
+  int Imin = 255;
+  int Imax = 0;
+
+  for (int intensity : I) {
+    Imin = std::min(Imin, intensity);
+    Imax = std::max(Imax, intensity);
+  }
+
+  if (Imin == Imax) {
+    image_output = image_input;
+    return true;
+  }
+
+  for (int i = 0, k = 0; i < size; i += 3, ++k) {
+    int Inew = ((I[k] - Imin) * 255) / (Imax - Imin);
+
+    float coeff = static_cast<float>(Inew) / static_cast<float>(I[k]);
+
+    image_output[i] = std::min(255, static_cast<int>(image_input[i] * coeff));
+    image_output[i + 1] = std::min(255, static_cast<int>(image_input[i + 1] * coeff));
+    image_output[i + 2] = std::min(255, static_cast<int>(image_input[i + 2] * coeff));
+  }
+
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PostProcessingImpl() {
+  auto* output = reinterpret_cast<int*>(task_data->outputs[0]);
+  std::copy(image_output.begin(), image_output.end(), output);
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::PreProcessingImpl() {
+  if (world.rank() == 0) {
+    int size = task_data->inputs_count[0];
+    image_input = std::vector<int>(size);
+    auto* tmp_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+    std::copy(tmp_ptr, tmp_ptr + size, image_input.begin());
+    image_output = {};
+    return true;
+  }
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::ValidationImpl() {
+  if (world.rank() == 0) {
+    int size = task_data->inputs_count[0];
+    if (size % 3 != 0) return false;
+
+    for (int i = 0; i < size; ++i) {
+      int value = reinterpret_cast<int*>(task_data->inputs[0])[i];
+      if (value < 0 || value > 255) {
+        return false;
+      }
+    }
+
+    return ((!task_data->inputs.empty() && !task_data->outputs.empty()) &&
+            (!task_data->inputs_count.empty() && task_data->inputs_count[0] != 0) &&
+            (!task_data->outputs_count.empty() && task_data->outputs_count[0] != 0));
+  }
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::RunImpl() {
+  int size = 0;
+  if (world.rank() == 0) {
+    size = image_input.size();
+  }
+
+  broadcast(world, size, 0);
+
+  int num_pixels = 0;
+  int pixels_per_process = 0;
+  int extra_pixels = 0;
+  if (world.rank() == 0) {
+    num_pixels = size / 3;
+    pixels_per_process = num_pixels / world.size();
+    extra_pixels = num_pixels % world.size();
+  }
+
+  broadcast(world, num_pixels, 0);
+  broadcast(world, pixels_per_process, 0);
+  broadcast(world, extra_pixels, 0);
+
+  int local_pixels = pixels_per_process + (world.rank() < extra_pixels ? 1 : 0);
+
+  std::vector<int> offset(world.size(), 0);
+  std::vector<int> send_counts(world.size(), 0);
+
+  if (world.rank() == 0) {
+    for (int proc = 0; proc < world.size(); ++proc) {
+      send_counts[proc] = (pixels_per_process + (proc < extra_pixels ? 1 : 0)) * 3;
+      if (proc > 0) {
+        offset[proc] = offset[proc - 1] + send_counts[proc - 1];
+      }
+    }
+  }
+
+  broadcast(world, send_counts.data(), send_counts.size(), 0);
+  broadcast(world, offset.data(), offset.size(), 0);
+
+  std::vector<int> local_input(local_pixels * 3);
+  boost::mpi::scatterv(world, image_input.data(), send_counts, offset, local_input.data(), local_pixels * 3, 0);
+
+  int local_Imin = 255;
+  int local_Imax = 0;
+  std::vector<int> local_I(local_pixels);
+  for (int i = 0, k = 0; i < local_pixels * 3; i += 3, ++k) {
+    int R = local_input[i];
+    int G = local_input[i + 1];
+    int B = local_input[i + 2];
+
+    local_I[k] = static_cast<int>(0.299 * static_cast<double>(R) + 0.587 * static_cast<double>(G) +
+                                  0.114 * static_cast<double>(B));
+    local_Imin = std::min(local_Imin, local_I[k]);
+    local_Imax = std::max(local_Imax, local_I[k]);
+  }
+
+  int global_Imin;
+  int global_Imax;
+  boost::mpi::all_reduce(world, local_Imin, global_Imin, boost::mpi::minimum<int>());
+  boost::mpi::all_reduce(world, local_Imax, global_Imax, boost::mpi::maximum<int>());
+
+  if (global_Imin == global_Imax) {
+    if (world.rank() == 0) {
+      image_output = image_input;
+    }
+    return true;
+  }
+
+  std::vector<int> local_output(local_pixels * 3);
+  for (int i = 0, k = 0; i < local_pixels * 3; i += 3, ++k) {
+    int Inew = ((local_I[k] - global_Imin) * 255) / (global_Imax - global_Imin);
+    float coeff = static_cast<float>(Inew) / static_cast<float>(local_I[k]);
+
+    local_output[i] = std::min(255, static_cast<int>(local_input[i] * coeff));
+    local_output[i + 1] = std::min(255, static_cast<int>(local_input[i + 1] * coeff));
+    local_output[i + 2] = std::min(255, static_cast<int>(local_input[i + 2] * coeff));
+  }
+
+  if (world.rank() == 0) {
+    image_output.resize(size);
+  }
+
+  boost::mpi::gatherv(world, local_output.data(), local_pixels * 3, image_output.data(), send_counts, offset, 0);
+
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::PostProcessingImpl() {
+  if (world.rank() == 0) {
+    auto* output = reinterpret_cast<int*>(task_data->outputs[0]);
+    std::copy(image_output.begin(), image_output.end(), output);
+  }
+  return true;
+}

--- a/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
+++ b/tasks/mpi/Konstantinov_I_histogram_stretching/src/ops_mpi.cpp
@@ -4,6 +4,7 @@
 #include <boost/mpi/collectives/all_reduce.hpp>
 #include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/scatterv.hpp>
+#include <boost/mpi/collectives/gatherv.hpp>
 #include <vector>
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::PreProcessingImpl() {
@@ -65,9 +66,9 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchSeq::Run
 
     float coeff = static_cast<float>(inew) / static_cast<float>(I_[k]);
 
-    image_output_[i] = std::min(255, static_cast<int>(image_input_[i] * coeff));
-    image_output_[i + 1] = std::min(255, static_cast<int>(image_input_[i + 1] * coeff));
-    image_output_[i + 2] = std::min(255, static_cast<int>(image_input_[i + 2] * coeff));
+    image_output_[i] = std::min(255, static_cast<int>(static_cast<float>(image_input_[i]) * coeff));
+    image_output_[i + 1] = std::min(255, static_cast<int>(static_cast<float>(image_input_[i + 1]) * coeff));
+    image_output_[i + 2] = std::min(255, static_cast<int>(static_cast<float>(image_input_[i + 2]) * coeff));
   }
 
   return true;
@@ -93,7 +94,7 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::Pre
 
 bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::ValidationImpl() {
   if (world_.rank() == 0) {
-    int size = static_cast<float>(task_data->inputs_count[0]);
+    int size = static_cast<int>(task_data->inputs_count[0]);
     if (size % 3 != 0) {
       return false;
     }
@@ -183,9 +184,9 @@ bool konstantinov_i_linear_histogram_stretch_mpi::LinearHistogramStretchMpi::Run
     int inew = ((local_i[k] - global_imin) * 255) / (global_imax - global_imin);
     float coeff = static_cast<float>(inew) / static_cast<float>(local_i[k]);
 
-    local_output[i] = std::min(255, static_cast<int>(local_input[i] * coeff));
-    local_output[i + 1] = std::min(255, static_cast<int>(local_input[i + 1] * coeff));
-    local_output[i + 2] = std::min(255, static_cast<int>(local_input[i + 2] * coeff));
+    local_output[i] = std::min(255, static_cast<int>(static_cast<float>(local_input[i]) * coeff));
+    local_output[i + 1] = std::min(255, static_cast<int>(static_cast<float>(local_input[i + 1]) * coeff));
+    local_output[i + 2] = std::min(255, static_cast<int>(static_cast<float>(local_input[i + 2]) * coeff));
   }
 
   if (world_.rank() == 0) {

--- a/tasks/seq/Konstantinov_I_histogram_stretching/func_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/func_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <vector>
 
 #include "seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp"

--- a/tasks/seq/Konstantinov_I_histogram_stretching/func_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/func_tests/main.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <memory>
+#include <random>
 #include <vector>
 
 #include "seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp"

--- a/tasks/seq/Konstantinov_I_histogram_stretching/func_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/func_tests/main.cpp
@@ -1,0 +1,230 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp"
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_correct_image) {
+  const int count_size_vector = 6;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = {15, 50, 45, 101, 92, 79};
+  std::vector<int> out_vec(count_size_vector, 0);
+  std::vector<int> res_exp_out = {0, 0, 0, 255, 252, 216};
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_EQ(testTaskSequential.ValidationImpl(), true);
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  ASSERT_EQ(res_exp_out, out_vec);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_correct_image2) {
+  const int width = 20;
+  const int height = 20;
+  const int count_size_vector = width * height * 3;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec(count_size_vector, 0);
+  std::vector<int> res_exp_out(count_size_vector, 0);
+
+  int Imin = 255;
+  int Imax = 0;
+  std::vector<int> intensity(width * height);
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    int R = in_vec[i];
+    int G = in_vec[i + 1];
+    int B = in_vec[i + 2];
+    intensity[k] = static_cast<int>(0.299 * R + 0.587 * G + 0.114 * B);
+    Imin = std::min(Imin, intensity[k]);
+    Imax = std::max(Imax, intensity[k]);
+  }
+
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    if (Imin == Imax) {
+      res_exp_out[i] = in_vec[i];
+      res_exp_out[i + 1] = in_vec[i + 1];
+      res_exp_out[i + 2] = in_vec[i + 2];
+      continue;
+    }
+    int Inew = ((intensity[k] - Imin) * 255) / (Imax - Imin);
+    float coeff = static_cast<float>(Inew) / static_cast<float>(intensity[k]);
+    res_exp_out[i] = std::min(255, static_cast<int>(in_vec[i] * coeff));
+    res_exp_out[i + 1] = std::min(255, static_cast<int>(in_vec[i + 1] * coeff));
+    res_exp_out[i + 2] = std::min(255, static_cast<int>(in_vec[i + 2] * coeff));
+  }
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_EQ(testTaskSequential.ValidationImpl(), true);
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+
+  ASSERT_EQ(res_exp_out, out_vec);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_correct_image3) {
+  const int width = 128;
+  const int height = 128;
+  const int count_size_vector = width * height * 3;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec(count_size_vector, 0);
+  std::vector<int> res_exp_out(count_size_vector, 0);
+
+  int Imin = 255;
+  int Imax = 0;
+  std::vector<int> intensity(width * height);
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    int R = in_vec[i];
+    int G = in_vec[i + 1];
+    int B = in_vec[i + 2];
+    intensity[k] = static_cast<int>(0.299 * R + 0.587 * G + 0.114 * B);
+    Imin = std::min(Imin, intensity[k]);
+    Imax = std::max(Imax, intensity[k]);
+  }
+
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    if (Imin == Imax) {
+      res_exp_out[i] = in_vec[i];
+      res_exp_out[i + 1] = in_vec[i + 1];
+      res_exp_out[i + 2] = in_vec[i + 2];
+      continue;
+    }
+    int Inew = ((intensity[k] - Imin) * 255) / (Imax - Imin);
+    float coeff = static_cast<float>(Inew) / static_cast<float>(intensity[k]);
+    res_exp_out[i] = std::min(255, static_cast<int>(in_vec[i] * coeff));
+    res_exp_out[i + 1] = std::min(255, static_cast<int>(in_vec[i + 1] * coeff));
+    res_exp_out[i + 2] = std::min(255, static_cast<int>(in_vec[i + 2] * coeff));
+  }
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_EQ(testTaskSequential.ValidationImpl(), true);
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+
+  ASSERT_EQ(res_exp_out, out_vec);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_correct_image4) {
+  const int width = 1024;
+  const int height = 512;
+  const int count_size_vector = width * height * 3;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec(count_size_vector, 0);
+  std::vector<int> res_exp_out(count_size_vector, 0);
+
+  int Imin = 255;
+  int Imax = 0;
+  std::vector<int> intensity(width * height);
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    int R = in_vec[i];
+    int G = in_vec[i + 1];
+    int B = in_vec[i + 2];
+    intensity[k] = static_cast<int>(0.299 * R + 0.587 * G + 0.114 * B);
+    Imin = std::min(Imin, intensity[k]);
+    Imax = std::max(Imax, intensity[k]);
+  }
+
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    if (Imin == Imax) {
+      res_exp_out[i] = in_vec[i];
+      res_exp_out[i + 1] = in_vec[i + 1];
+      res_exp_out[i + 2] = in_vec[i + 2];
+      continue;
+    }
+    int Inew = ((intensity[k] - Imin) * 255) / (Imax - Imin);
+    float coeff = static_cast<float>(Inew) / static_cast<float>(intensity[k]);
+    res_exp_out[i] = std::min(255, static_cast<int>(in_vec[i] * coeff));
+    res_exp_out[i + 1] = std::min(255, static_cast<int>(in_vec[i + 1] * coeff));
+    res_exp_out[i + 2] = std::min(255, static_cast<int>(in_vec[i + 2] * coeff));
+  }
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_EQ(testTaskSequential.ValidationImpl(), true);
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+
+  ASSERT_EQ(res_exp_out, out_vec);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_incorrect_rgb_size_image) {
+  const int count_size_vector = 8;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = {15, 50, 45, 101, 92, 79, 0, 0};
+  std::vector<int> out_vec(count_size_vector, 0);
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_NE(testTaskSequential.ValidationImpl(), true);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_incorrect_value_color_range_image) {
+  const int count_size_vector = 12;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = {631, -2, 45, 101, 92, 79, 0, 0, 300, 255, 10, 15};
+  std::vector<int> out_vec(count_size_vector, 0);
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_EQ(testTaskSequential.ValidationImpl(), false);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_empty_image) {
+  const int count_size_vector = 0;
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq testTaskSequential(task_data_seq);
+
+  std::vector<int> in_vec = {};
+  std::vector<int> out_vec(count_size_vector, 0);
+
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  ASSERT_EQ(testTaskSequential.ValidationImpl(), false);
+}

--- a/tasks/seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp
@@ -1,5 +1,7 @@
 #pragma once
-#include <string>
+
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace konstantinov_i_linear_histogram_stretch_seq {
+std::vector<int> GetRandomImage(int sz);
+void LinearHistogramStretch(const std::vector<int>& input, std::vector<int>& output);
+
+class LinearHistogramStretchSeq : public ppc::core::Task {
+ public:
+  explicit LinearHistogramStretchSeq(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> I;
+  std::vector<int> image_input;
+  std::vector<int> image_output;
+};
+}  // namespace konstantinov_i_linear_histogram_stretch_seq

--- a/tasks/seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp
@@ -6,7 +6,6 @@
 
 namespace konstantinov_i_linear_histogram_stretch_seq {
 std::vector<int> GetRandomImage(int sz);
-void LinearHistogramStretch(const std::vector<int>& input, std::vector<int>& output);
 
 class LinearHistogramStretchSeq : public ppc::core::Task {
  public:
@@ -17,8 +16,8 @@ class LinearHistogramStretchSeq : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<int> I;
-  std::vector<int> image_input;
-  std::vector<int> image_output;
+  std::vector<int> I_;
+  std::vector<int> image_input_;
+  std::vector<int> image_output_;
 };
 }  // namespace konstantinov_i_linear_histogram_stretch_seq

--- a/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -2,10 +2,10 @@
 
 #include <boost/mpi/communicator.hpp>
 #include <boost/mpi/timer.hpp>
-#include <functional>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <random>
 #include <vector>

--- a/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp"
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_pipeline_run) {
+  const int width = 4000;
+  const int height = 4000;
+  const int count_size_vector = width * height * 3;
+
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec(count_size_vector, 0);
+  std::vector<int> res_exp_out(count_size_vector, 0);
+
+  int Imin = 255;
+  int Imax = 0;
+  std::vector<int> intensity(width * height);
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    int R = in_vec[i];
+    int G = in_vec[i + 1];
+    int B = in_vec[i + 2];
+    intensity[k] = static_cast<int>(0.299 * R + 0.587 * G + 0.114 * B);
+    Imin = std::min(Imin, intensity[k]);
+    Imax = std::max(Imax, intensity[k]);
+  }
+
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    if (Imin == Imax) {
+      res_exp_out[i] = in_vec[i];
+      res_exp_out[i + 1] = in_vec[i + 1];
+      res_exp_out[i + 2] = in_vec[i + 2];
+      continue;
+    }
+    int Inew = ((intensity[k] - Imin) * 255) / (Imax - Imin);
+    float coeff = static_cast<float>(Inew) / static_cast<float>(intensity[k]);
+    res_exp_out[i] = std::min(255, static_cast<int>(in_vec[i] * coeff));
+    res_exp_out[i + 1] = std::min(255, static_cast<int>(in_vec[i + 1] * coeff));
+    res_exp_out[i + 2] = std::min(255, static_cast<int>(in_vec[i + 2] * coeff));
+  }
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  auto testTaskSequential =
+      std::make_shared<konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq>(task_data_seq);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(res_exp_out, out_vec);
+}
+
+TEST(Konstantinov_i_linear_histogram_stretch_seq, test_task_run) {
+  const int width = 4000;
+  const int height = 4000;
+  const int count_size_vector = width * height * 3;
+
+  std::vector<int> in_vec = konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(count_size_vector);
+  std::vector<int> out_vec(count_size_vector, 0);
+  std::vector<int> res_exp_out(count_size_vector, 0);
+
+  int Imin = 255;
+  int Imax = 0;
+  std::vector<int> intensity(width * height);
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    int R = in_vec[i];
+    int G = in_vec[i + 1];
+    int B = in_vec[i + 2];
+    intensity[k] = static_cast<int>(0.299 * R + 0.587 * G + 0.114 * B);
+    Imin = std::min(Imin, intensity[k]);
+    Imax = std::max(Imax, intensity[k]);
+  }
+
+  for (int i = 0, k = 0; i < count_size_vector; i += 3, ++k) {
+    if (Imin == Imax) {
+      res_exp_out[i] = in_vec[i];
+      res_exp_out[i + 1] = in_vec[i + 1];
+      res_exp_out[i + 2] = in_vec[i + 2];
+      continue;
+    }
+    int Inew = ((intensity[k] - Imin) * 255) / (Imax - Imin);
+    float coeff = static_cast<float>(Inew) / static_cast<float>(intensity[k]);
+    res_exp_out[i] = std::min(255, static_cast<int>(in_vec[i] * coeff));
+    res_exp_out[i + 1] = std::min(255, static_cast<int>(in_vec[i + 1] * coeff));
+    res_exp_out[i + 2] = std::min(255, static_cast<int>(in_vec[i + 2] * coeff));
+  }
+
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
+  auto testTaskSequential =
+      std::make_shared<konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq > (task_data_seq);
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
+  task_data_seq->inputs_count.emplace_back(in_vec.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));
+  task_data_seq->outputs_count.emplace_back(out_vec.size());
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(res_exp_out, out_vec);
+}

--- a/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
@@ -101,7 +102,7 @@ TEST(Konstantinov_i_linear_histogram_stretch_seq, test_task_run) {
 
   std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   auto testTaskSequential =
-      std::make_shared<konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq > (task_data_seq);
+      std::make_shared<konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq>(task_data_seq);
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_vec.data()));
   task_data_seq->inputs_count.emplace_back(in_vec.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_vec.data()));

--- a/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/perf_tests/main.cpp
@@ -1,8 +1,17 @@
 #include <gtest/gtest.h>
 
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/timer.hpp>
+#include <functional>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <random>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
 #include "seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp"
 
 TEST(Konstantinov_i_linear_histogram_stretch_seq, test_pipeline_run) {

--- a/tasks/seq/Konstantinov_I_histogram_stretching/src/ops_seq.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/src/ops_seq.cpp
@@ -1,0 +1,88 @@
+#include "seq/Konstantinov_I_histogram_stretching/include/ops_seq.hpp"
+
+#include <random>
+#include <thread>
+
+std::vector<int> konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(int sz) {
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  std::vector<int> vec(sz);
+  for (int i = 0; i < sz; i++) {
+    vec[i] = dist(gen);
+  }
+  return vec;
+}
+
+bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::PreProcessingImpl() {
+
+  int size = task_data->inputs_count[0];
+  image_input = std::vector<int>(size);
+  auto* tmp_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + size, image_input.begin());
+
+  int pixel_count = size / 3;
+  I.resize(pixel_count);
+  for (int i = 0, k = 0; i < size; i += 3, ++k) {
+    int r = image_input[i];
+    int g = image_input[i + 1];
+    int b = image_input[i + 2];
+
+    I[k] = static_cast<int>(0.299 * static_cast<double>(r) + 0.587 * static_cast<double>(g) +
+                            0.114 * static_cast<double>(b));
+  }
+
+  image_output = {};
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::ValidationImpl() {
+  int size = task_data->inputs_count[0];
+  if (size % 3 != 0) return false;
+
+  for (int i = 0; i < size; ++i) {
+    int value = reinterpret_cast<int*>(task_data->inputs[0])[i];
+    if (value < 0 || value > 255) {
+      return false;
+    }
+  }
+
+  return ((!task_data->inputs.empty() && !task_data->outputs.empty()) &&
+          (!task_data->inputs_count.empty() && task_data->inputs_count[0] != 0) &&
+          (!task_data->outputs_count.empty() && task_data->outputs_count[0] != 0));
+}
+
+bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::RunImpl() {
+
+  int size = image_input.size();
+  image_output.resize(size);
+  int Imin = 255;
+  int Imax = 0;
+
+  for (int intensity : I) {
+    Imin = std::min(Imin, intensity);
+    Imax = std::max(Imax, intensity);
+  }
+
+  if (Imin == Imax) {
+    image_output = image_input;
+    return true;
+  }
+
+  for (int i = 0, k = 0; i < size; i += 3, ++k) {
+    int Inew = ((I[k] - Imin) * 255) / (Imax - Imin);
+
+    float coeff = static_cast<float>(Inew) / static_cast<float>(I[k]);
+
+    image_output[i] = std::min(255, static_cast<int>(image_input[i] * coeff));
+    image_output[i + 1] = std::min(255, static_cast<int>(image_input[i + 1] * coeff));
+    image_output[i + 2] = std::min(255, static_cast<int>(image_input[i + 2] * coeff));
+  }
+
+  return true;
+}
+
+bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::PostProcessingImpl() {
+  auto* output = reinterpret_cast<int*>(task_data->outputs[0]);
+  std::copy(image_output.begin(), image_output.end(), output);
+  return true;
+}

--- a/tasks/seq/Konstantinov_I_histogram_stretching/src/ops_seq.cpp
+++ b/tasks/seq/Konstantinov_I_histogram_stretching/src/ops_seq.cpp
@@ -14,7 +14,6 @@ std::vector<int> konstantinov_i_linear_histogram_stretch_seq::GetRandomImage(int
 }
 
 bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::PreProcessingImpl() {
-
   int size = task_data->inputs_count[0];
   image_input = std::vector<int>(size);
   auto* tmp_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
@@ -52,7 +51,6 @@ bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::Val
 }
 
 bool konstantinov_i_linear_histogram_stretch_seq::LinearHistogramStretchSeq::RunImpl() {
-
   int size = image_input.size();
   image_output.resize(size);
   int Imin = 255;


### PR DESCRIPTION
**Предположение**: На вход подается матрица (вектор) цветного изображения, которое уже было предварительно обработано. Вектор имеет вид: [R1, G1, B1, R2, G2, B2, ..., RN, GN, BN], где каждый элемент представляет цветовые компоненты (R, G, B) для каждого пикселя.
**Описание последовательной задачи:**
- Вектор image_input обрабатывается для извлечения значений красного (R), зеленого (G) и синего (B) каналов для каждого пикселя.
- На основе значений RGB для каждого пикселя вычисляется массив яркостей I. Одновременно находятся минимальное (Imin) и максимальное (Imax) значения в массиве яркостей.
- Применяется линейная растяжка гистограммы, в результате которой вычисляются новые значения яркостей Inew.
- Определяется коэффициент масштабирования coeff для обратного преобразования массива яркостей в цветовые компоненты RGB.
- Вычисляются новые значения RGB, и формируется новый вектор изображения image_output, который возвращается как результат.

**Описание задачи с использованием MPI:**

_1.Главный процесс определяет общий размер входного изображения (image_input.size())._

1.1. Размер изображения передается всем процессам через операцию broadcast.

1.2. Вычисляется общее количество пикселей и их распределение между процессами:
- num_pixels: общее количество пикселей (размер изображения делится на 3, так как каждые три значения представляют RGB компоненты одного пикселя, аналогично последовательной версии).
- pixels_per_process: базовое количество пикселей, обрабатываемое каждым процессом.
- extra_pixels: оставшиеся пиксели, которые не удалось равномерно распределить; они распределяются между первыми процессами.

1.3. Для каждого процесса вычисляется локальное количество пикселей local_pixels.

_2. Главный процесс вычисляет массивы send_counts и offset:_

- send_counts: количество элементов, которые каждый процесс получит из общего массива данных (равно local_pixels * 3, так как каждый пиксель имеет 3 компоненты RGB).
- offset: смещение данных для каждого процесса относительно начала исходного массива.

2.1. Эти массивы передаются всем процессам через broadcast.

_3. Данные распределяются между процессами с помощью операции scatterv. Каждый процесс получает свою локальную часть массива данных (local_input)._
_4. Каждый процесс обрабатывает свою часть данных:_
- Вычисляются локальные значения яркости local_I.
- Находятся локальные минимум (local_Imin) и максимум (local_Imax) яркости.

_5. Локальные минимумы и максимумы собираются в глобальные значения global_Imin и global_Imax с помощью операции all_reduce._

_6. Используя глобальные значения global_Imin и global_Imax, каждый процесс выполняет растяжение гистограммы, вычисляя новые значения яркости Inew и коэффициент масштабирования coeff. Результаты сохраняются в local_output._

_7. Обработанные данные собираются с помощью операции gatherv. Каждый процесс отправляет свои результаты главному процессу, который формирует итоговый массив image_output._

**Этот подход позволяет эффективно распределить обработку изображения между несколькими процессами, что особенно полезно для больших изображений.**